### PR TITLE
zip_extract: handle directories within zip files

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -585,9 +585,11 @@ int zip_extract(const char *zipname, const char *dir,
             goto out;
         }
 
-        if (!mz_zip_reader_extract_to_file(&zip_archive, i, path, 0)) {
-            // Cannot extract zip archive to file
-            goto out;
+        if (!mz_zip_reader_is_file_a_directory(&zip_archive, i)) {
+            if (!mz_zip_reader_extract_to_file(&zip_archive, i, path, 0)) {
+                // Cannot extract zip archive to file
+                goto out;
+            }
         }
 
         if (on_extract) {


### PR DESCRIPTION
mz_zip_reader_extract_to_file fails when you ask it to extract a directory (according to the comment on line 621 of miniz.h and confirmed by my tests), thus zip_extract will fail if it attempts to decompress a zip file if that zip file contains a directory (there is an exception but I will not go into it here). This patch corrects the issue.