### PR TITLE
Fix possible NULL-Ptr detection from clang

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -3030,6 +3030,7 @@ static MZ_FORCEINLINE mz_bool mz_zip_array_ensure_room(mz_zip_archive *pZip, mz_
 
 static MZ_FORCEINLINE mz_bool mz_zip_array_push_back(mz_zip_archive *pZip, mz_zip_array *pArray, const void *pElements, size_t n)
 {
+  if( 0 == n ) return MZ_TRUE;
   size_t orig_size = pArray->m_size; if (!mz_zip_array_resize(pZip, pArray, orig_size + n, MZ_TRUE)) return MZ_FALSE;
   memcpy((mz_uint8*)pArray->m_p + orig_size * pArray->m_element_size, pElements, n * pArray->m_element_size);
   return MZ_TRUE;


### PR DESCRIPTION
When enabling the clang adress-saniziser the function mz_zip_array_push_back used with a size of 0 bytes will be detected as a possible NULL-pointer-refererence-error and the test failes. My pull request will close this gap.