### PR TITLE
Use correct level_of_compression variable for check

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4427,8 +4427,7 @@ mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, 
   size_t archive_name_size;
   mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
   MZ_FILE *pSrc_file = NULL;
-
-  if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pArchive_name) || ((comment_size) && (!pComment)) || (level > MZ_UBER_COMPRESSION))
+  if ((!pZip) || (!pZip->m_pState) || (pZip->m_zip_mode != MZ_ZIP_MODE_WRITING) || (!pArchive_name) || ((comment_size) && (!pComment)) || ( level_and_flags > MZ_UBER_COMPRESSION))
     return MZ_FALSE;
 
   local_dir_header_ofs = cur_archive_file_ofs = pZip->m_archive_size;


### PR DESCRIPTION
This commit will fix a compiler warning which detects a uninitialized variable which will be checked to break. From my point of view we need to check the incoming parameter from the function call.