### PR TITLE
Fix https://www.viva64.com/en/w/v769/

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -83,10 +83,14 @@ static int mkpath(const char *path) {
 }
 
 static char *strrpl(const char *str, size_t n, char oldchar, char newchar) {
-    char *rpl = (char *)calloc((1 + n), sizeof(char));
-    char *begin = rpl;
     char c;
     size_t i;
+    char *rpl = (char *)calloc((1 + n), sizeof(char));
+    char *begin = rpl;
+    if (!rpl) {
+        return NULL;
+    }
+
     for(i = 0; (i < n) && (c = *str++); ++i) {
         if (c == oldchar) {
             c = newchar;


### PR DESCRIPTION
The 'rpl' pointer in the 'rpl ++' expression could be nullptr. In such
case, resulting value will be senseless and it should not be used.
Check lines: 94, 86.