### PR TITLE
Use project-local CMake variables instead of top-level CMake variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@
 # Temporary
 *.swp
 .DS_Store
+
+# CMake
+CMakeScripts
+*.cmake
+
+# Xcode
+*.build
+*.xcodeproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ endif (MSVC)
 
 # zip
 set(SRC src/miniz.h src/zip.h src/zip.c)
-add_library(${CMAKE_PROJECT_NAME} ${SRC})
+add_library(${PROJECT_NAME} ${SRC})
 
 # test
 enable_testing()
 add_subdirectory(test)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
-add_sanitizers(${CMAKE_PROJECT_NAME} test.exe)
+add_sanitizers(${PROJECT_NAME} test.exe)


### PR DESCRIPTION
This PR replaces the CMake variables `CMAKE_PROJECT_NAME` and `CMAKE_SOURCE_DIR` with `PROJECT_NAME` and `PROJECT_SOURCE_DIR`. This allows `zip` to be nested in other CMake projects using `include_subdirectory()` with CMake 3.x without changing the behavior when using CMake 2.8. This change is needed because the behavior of the `CMAKE_PROJECT_NAME` and `CMAKE_SOURCE_DIR` variables changed with CMake 3.x.

For example, in CMake 2.8, the [documentation states that `CMAKE_PROJECT_NAME` is](https://cmake.org/cmake/help/v2.8.12/cmake.html#variable:CMAKE_PROJECT_NAME)

> The name of the current project. This specifies name of the current project from the closest inherited PROJECT command.

While in CMake 3.12, the [documentation states that `CMAKE_PROJECT_NAME` is](https://cmake.org/cmake/help/v3.12/variable/CMAKE_PROJECT_NAME.html)

> The name of the top level project.

As a result, the call to `add_library(${CMAKE_PROJECT_NAME} ${SRC})` ends up specifying the name of the top-level project instead of `zip`.