### PR TITLE
Use target_include_directories to help dependents find the zip.h file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,13 @@ CMakeScripts
 # Xcode
 *.build
 *.xcodeproj
+zip.sln
+zip.vcxproj.filters
+zip.vcxproj
+ALL_BUILD.vcxproj.filters
+ALL_BUILD.vcxproj
+CMakeFiles/
+zip.dir/
+test/test.exe.vcxproj.filters
+test/test.exe.vcxproj
+test/test.exe.dir/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif (MSVC)
 # zip
 set(SRC src/miniz.h src/zip.h src/zip.c)
 add_library(${PROJECT_NAME} ${SRC})
+target_include_directories(${PROJECT_NAME} INTERFACE src)
 
 # test
 enable_testing()


### PR DESCRIPTION
When incorporating zip as a subdirectory in a larger CMake-based project, dependent targets need to be told where to find the zip.h file. The simplest way to do that is with a target_include_directories() call in the CMakeLists.txt file.