### PR TITLE
Add c99 support

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4134,8 +4134,13 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+#if _FILE_OFFSET_BITS == 64 || _POSIX_C_SOURCE >= 200112L
 #define MZ_FTELL64 ftello
 #define MZ_FSEEK64 fseeko
+#else
+#define MZ_FTELL64 ftell
+#define MZ_FSEEK64 fseek
+#endif
 #define MZ_FILE_STAT_STRUCT stat
 #define MZ_FILE_STAT stat
 #define MZ_FFLUSH fflush


### PR DESCRIPTION
I got warning when tried to compile with `--std=c99`

```
$ gcc -std=c99 -c zip.c
In file included from zip.c:35:
miniz.h: In function ‘mz_zip_file_read_func’:
miniz.h:4137:20: warning: implicit declaration of function ‘ftello’; did you mean ‘ftell’? [-Wimplicit-function-declaration]
 #define MZ_FTELL64 ftello
                    ^~~~~~
miniz.h:4657:22: note: in expansion of macro ‘MZ_FTELL64’
   mz_int64 cur_ofs = MZ_FTELL64(pZip->m_pState->m_pFile);
                      ^~~~~~~~~~
miniz.h:4138:20: warning: implicit declaration of function ‘fseeko’; did you mean ‘fseek’? [-Wimplicit-function-declaration]
 #define MZ_FSEEK64 fseeko
                    ^~~~~~
miniz.h:4660:9: note: in expansion of macro ‘MZ_FSEEK64’
        (MZ_FSEEK64(pZip->m_pState->m_pFile, (mz_int64)file_ofs, SEEK_SET))))
```
`man ftello` says that `ftello` feature support should be ckecked with `_FILE_OFFSET_BITS == 64 || _POSIX_C_SOURCE >= 200112L`