### PR TITLE
Fix cast from const warning

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -108,7 +108,7 @@ static char *strrpl(const char *str, size_t n, char oldchar, char newchar) {
 
 struct zip_entry_t {
   int index;
-  const char *name;
+  char *name;
   mz_uint64 uncomp_size;
   mz_uint64 comp_size;
   mz_uint32 uncomp_crc32;


### PR DESCRIPTION
See https://github.com/kuba--/zip/blob/master/src/zip.c#L322, here called `free` for `const char*`.