### PR TITLE
Fix missing field initializer warnings

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -574,7 +574,10 @@ int zip_entry_fwrite(struct zip_t *zip, const char *filename) {
   size_t n = 0;
   FILE *stream = NULL;
   mz_uint8 buf[MZ_ZIP_MAX_IO_BUF_SIZE] = {0};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
   struct MZ_FILE_STAT_STRUCT file_stat = {0};
+#pragma clang diagnostic pop
 
   if (!zip) {
     // zip_t handler is not initialized
@@ -667,7 +670,10 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
   mz_zip_archive *pzip = NULL;
   mz_uint idx;
   mz_uint32 xattr = 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
   mz_zip_archive_file_stat info = {0};
+#pragma clang diagnostic pop
 
   if (!zip) {
     // zip_t handler is not initialized
@@ -745,7 +751,10 @@ int zip_create(const char *zipname, const char *filenames[], size_t len) {
   int status = 0;
   size_t i;
   mz_zip_archive zip_archive;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
   struct MZ_FILE_STAT_STRUCT file_stat = {0};
+#pragma clang diagnostic push
   mz_uint32 ext_attributes = 0;
 
   if (!zipname || strlen(zipname) < 1) {
@@ -802,7 +811,10 @@ int zip_extract(const char *zipname, const char *dir,
   mz_uint i, n;
   char path[MAX_PATH + 1] = {0};
   mz_zip_archive zip_archive;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
   mz_zip_archive_file_stat info = {0};
+#pragma clang diagnostic pop
   size_t dirlen = 0;
   mz_uint32 xattr = 0;
 

--- a/test/test.c
+++ b/test/test.c
@@ -154,7 +154,10 @@ static size_t on_extract(void *arg, unsigned long long offset, const void *data,
 }
 
 static void test_extract(void) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
   struct buffer_t buf = {0};
+#pragma clang diagnostic pop
 
   struct zip_t *zip = zip_open(ZIPNAME, 0, 'r');
   assert(zip != NULL);


### PR DESCRIPTION
I got on Mac OS X with clang `Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)` 

```
FAILED: test/CMakeFiles/test.exe.dir/test.c.o 
/usr/bin/gcc  -I../test/../src -std=c99 -Wall -Wextra -pedantic -Werror -O3 -DNDEBUG -isysroot /Applications/Xcode-6.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -mmacosx-version-min=10.7 -MD -MT test/CMakeFiles/test.exe.dir/test.c.o -MF test/CMakeFiles/test.exe.dir/test.c.o.d -o test/CMakeFiles/test.exe.dir/test.c.o   -c ../test/test.c
../test/test.c:157:27: error: missing field 'size' initializer [-Werror,-Wmissing-field-initializers]
  struct buffer_t buf = {0};
```