### PR TITLE
Fix ssize_t check for MXE

### DIFF
--- a/src/zip.h
+++ b/src/zip.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#ifndef _SSIZE_T
+#if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T)
 #define _SSIZE_T
 typedef long  ssize_t;  /* byte count or error */
 #endif


### PR DESCRIPTION
The MXE build environment (to cross-compile Windows binaries from Linux) uses the _SSIZE_T_DEFINED instead of the _SSIZE_T, and fails otherwise due to conflicting types.