### PR TITLE
Add support for Android NDK stdint.h.

### DIFF
--- a/src/zip.h
+++ b/src/zip.h
@@ -19,7 +19,8 @@
 extern "C" {
 #endif
 
-#if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T) && !defined(_SSIZE_T_)
+#if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
+    !defined(_SSIZE_T) && !defined(_SSIZE_T_)
 #define _SSIZE_T
 typedef long  ssize_t;  /* byte count or error */
 #endif


### PR DESCRIPTION
Some stdint.h headers define `_SSIZE_T_DEFINED_` instead of
`_SSIZE_T_DEFINED`. Allow for this in the ifdef checks in zip.h