### PR TITLE
Fix UNIX file permissions

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -277,7 +277,14 @@ int zip_entry_open(struct zip_t *zip, const char *entryname) {
   zip->entry.header_offset = zip->archive.m_archive_size;
   memset(zip->entry.header, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE * sizeof(mz_uint8));
   zip->entry.method = 0;
+
+  // UNIX or APPLE
+#if MZ_PLATFORM == 3 || MZ_PLATFORM == 19
+  // regular file with rw-r--r-- persmissions
+  zip->entry.external_attr = (mz_uint32)(0100644) << 16;
+#else
   zip->entry.external_attr = 0;
+#endif
 
   num_alignment_padding_bytes =
       mz_zip_writer_compute_padding_needed_for_file_alignment(pzip);

--- a/test/test.c
+++ b/test/test.c
@@ -29,6 +29,8 @@
 #define XFILE "7.txt\0"
 #define XMODE 0100777
 
+#define UNIXMODE 0100644
+
 #define UNUSED(x) (void)x
 
 static int total_entries = 0;
@@ -435,6 +437,35 @@ static void test_mtime(void) {
   remove(ZIPNAME);
 }
 
+static void test_unix_permissions(void) {
+#if defined(_WIN64) || defined(_WIN32) || defined(__WIN32__)
+#else
+  // UNIX or APPLE
+  struct MZ_FILE_STAT_STRUCT file_stats;
+
+  remove(ZIPNAME);
+
+  struct zip_t *zip = zip_open(ZIPNAME, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  assert(zip != NULL);
+
+  assert(0 == zip_entry_open(zip, RFILE));
+  assert(0 == zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+  assert(0 == zip_entry_close(zip));
+
+  zip_close(zip);
+
+  remove(RFILE);
+
+  assert(0 == zip_extract(ZIPNAME, ".", NULL, NULL));
+
+  assert(0 == MZ_FILE_STAT(RFILE, &file_stats));
+  assert(UNIXMODE == file_stats.st_mode);
+
+  remove(RFILE);
+  remove(ZIPNAME);
+#endif
+}
+
 int main(int argc, char *argv[]) {
   UNUSED(argc);
   UNUSED(argv);
@@ -455,6 +486,7 @@ int main(int argc, char *argv[]) {
   test_write_permissions();
   test_exe_permissions();
   test_mtime();
+  test_unix_permissions();
 
   remove(ZIPNAME);
   return 0;


### PR DESCRIPTION
Need to explicity set UNIX file permissions when commpressing buffer
to entry. Without it later unpacked file can't be opened.

Fix #100