### PR TITLE
Update CMake files with Config install and some cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
         "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
         "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Wextra -Werror -pedantic")
+  if(ENABLE_COVERAGE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  endif()
 endif (MSVC)
 
 # zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,58 @@ if (NOT CMAKE_DISABLE_TESTING)
   add_sanitizers(${PROJECT_NAME} ${test_miniz_out})
 endif()
 
+####
+# Installation (https://github.com/forexample/package-example) {
+
+set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${VERSION_CONFIG}" COMPATIBILITY SameMajorVersion
+)
+
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${PROJECT_CONFIG}"
+    INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+    FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${NAMESPACE}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+# }
+
 install(TARGETS ${PROJECT_NAME}
+        EXPORT ${TARGETS_EXPORT_NAME}
         RUNTIME DESTINATION bin
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
-        COMPONENT library)
-install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h DESTINATION include)
+        INCLUDES DESTINATION ${INCLUDE_INSTALL_DIR}
+)
+install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h DESTINATION ${INCLUDE_INSTALL_DIR}/zip)
 
 # uninstall target (https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake)
 if(NOT TARGET uninstall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 2.8)
-project(zip)
-enable_language(C)
+cmake_minimum_required(VERSION 3.0)
+
+project(zip
+  LANGUAGES C
+  VERSION "0.1.15")
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-set(ZIP_VERSION "0.1.15")
+option(CMAKE_DISABLE_TESTING "Disable test creation" OFF)
 
 if (MSVC)
-  # Use secure functions by defaualt and suppress warnings about "deprecated" functions
+  # Use secure functions by default and suppress warnings about "deprecated" functions
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /D _CRT_NONSTDC_NO_WARNINGS=1 /D _CRT_SECURE_NO_WARNINGS=1")
@@ -19,7 +21,10 @@ endif (MSVC)
 # zip
 set(SRC src/miniz.h src/zip.h src/zip.c)
 add_library(${PROJECT_NAME} ${SRC})
-target_include_directories(${PROJECT_NAME} INTERFACE src)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include>
+)
 
 # test
 if (NOT CMAKE_DISABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,7 @@ if (NOT CMAKE_DISABLE_TESTING)
   enable_testing()
   add_subdirectory(test)
   find_package(Sanitizers)
-  add_sanitizers(${PROJECT_NAME} ${test_out})
-  add_sanitizers(${PROJECT_NAME} ${test_miniz_out})
+  add_sanitizers(${PROJECT_NAME} ${test_out} ${test_miniz_out})
 endif()
 
 ####

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(${test_miniz_out} zip)
 
 add_test(NAME ${test_out} COMMAND ${test_out})
 add_test(NAME ${test_miniz_out} COMMAND ${test_miniz_out})
+
+set(test_out ${test_out} PARENT_SCOPE)
+set(test_miniz_out ${test_miniz_out} PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
-  if(ENABLE_COVERAGE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftest-coverage")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-  endif()
-endif ()
-
 # test
 set(test_out test.out)
 set(test_miniz_out test_miniz.out)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,18 +11,13 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL
 endif ()
 
 # test
-include_directories(../src)
-
 set(test_out test.out)
 set(test_miniz_out test_miniz.out)
 
-if (WIN32)
-  set(test_out test.exe)
-  set(test_miniz_out test_miniz.exe)
-endif()
-
-add_executable(${test_out} test.c ../src/zip.c)
+add_executable(${test_out} test.c)
+target_link_libraries(${test_out} zip)
 add_executable(${test_miniz_out} test_miniz.c)
+target_link_libraries(${test_miniz_out} zip)
 
 add_test(NAME ${test_out} COMMAND ${test_out})
 add_test(NAME ${test_miniz_out} COMMAND ${test_miniz_out})


### PR DESCRIPTION
I want to add this package to the Hunter package manager: https://github.com/ruslo/hunter

To do so, we need to export the library target in the modern CMake fashion. No Hunter-specific changes need to be made since the library has no dependencies.

This line
`install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h DESTINATION ${INCLUDE_INSTALL_DIR}/zip)`
means that library consumers need to include
`#include <zip/zip.h>`
which avoids conflicts with other libraries that may use the same filename (`zip.h`).