### PR TITLE
Support for 64-bit fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build/
 /test/build/
 /xcodeproj/
+.vscode/
 
 # Object files
 *.o
@@ -54,3 +55,4 @@ zip.dir/
 test/test.exe.vcxproj.filters
 test/test.exe.vcxproj
 test/test.exe.dir/
+

--- a/src/zip.c
+++ b/src/zip.c
@@ -24,7 +24,6 @@
   ((((P)[0] >= 'A' && (P)[0] <= 'Z') || ((P)[0] >= 'a' && (P)[0] <= 'z')) &&   \
    (P)[1] == ':')
 #define FILESYSTEM_PREFIX_LEN(P) (HAS_DEVICE(P) ? 2 : 0)
-#define ISSLASH(C) ((C) == '/' || (C) == '\\')
 
 #else
 
@@ -48,7 +47,7 @@ int symlink(const char *target, const char *linkpath); // needed on Linux
 #endif
 
 #ifndef ISSLASH
-#define ISSLASH(C) ((C) == '/')
+#define ISSLASH(C) ((C) == '/' || (C) == '\\')
 #endif
 
 #define CLEANUP(ptr)                                                           \
@@ -78,8 +77,8 @@ static const char *base_name(const char *name) {
   return base;
 }
 
-static int mkpath(const char *path) {
-  char const *p;
+static int mkpath(char *path) {
+  char *p;
   char npath[MAX_PATH + 1];
   int len = 0;
   int has_device = HAS_DEVICE(path);
@@ -93,9 +92,19 @@ static int mkpath(const char *path) {
   }
   for (p = path + len; *p && len < MAX_PATH; p++) {
     if (ISSLASH(*p) && ((!has_device && len > 0) || (has_device && len > 2))) {
-      if (MKDIR(npath) == -1)
-        if (errno != EEXIST)
+#if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
+    defined(__MINGW32__)
+#else
+      if ('\\' == *p) {
+        *p = '/';
+      }
+#endif
+
+      if (MKDIR(npath) == -1) {
+        if (errno != EEXIST) {
           return -1;
+        }
+      }
     }
     npath[len++] = *p;
   }
@@ -665,7 +674,7 @@ ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf, size_t bufsize) {
   }
 
   if (!mz_zip_reader_extract_to_mem_no_alloc(pzip, (mz_uint)zip->entry.index,
-  buf, bufsize, 0, NULL,  0)) {
+                                             buf, bufsize, 0, NULL, 0)) {
     return -1;
   }
 
@@ -877,12 +886,19 @@ int zip_extract(const char *zipname, const char *dir,
       goto out;
     }
 
-    if ((((info.m_version_made_by >> 8) == 3) || ((info.m_version_made_by >> 8) == 19)) // if zip is produced on Unix or macOS (3 and 19 from section 4.4.2.2 of zip standard)
-        && info.m_external_attr & (0x20 << 24)) { // and has sym link attribute (0x80 is file, 0x40 is directory)
+    if ((((info.m_version_made_by >> 8) == 3) ||
+         ((info.m_version_made_by >> 8) ==
+          19)) // if zip is produced on Unix or macOS (3 and 19 from
+               // section 4.4.2.2 of zip standard)
+        && info.m_external_attr &
+               (0x20 << 24)) { // and has sym link attribute (0x80 is file, 0x40
+                               // is directory)
 #if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
     defined(__MINGW32__)
-#else      
-      if (info.m_uncomp_size > MAX_PATH || !mz_zip_reader_extract_to_mem_no_alloc(&zip_archive, i, symlink_to, MAX_PATH, 0, NULL, 0)) {
+#else
+      if (info.m_uncomp_size > MAX_PATH ||
+          !mz_zip_reader_extract_to_mem_no_alloc(&zip_archive, i, symlink_to,
+                                                 MAX_PATH, 0, NULL, 0)) {
         goto out;
       }
       symlink_to[info.m_uncomp_size] = '\0';


### PR DESCRIPTION
Add support for 64 bit fields in central directory by
updating `..._central_dir` functions in `miniz.h` header from upstream library.

It closes: #107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kuba--/zip/108)
<!-- Reviewable:end -->
