### PR TITLE
Add delete entry function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if (MSVC)
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
         "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
         "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Wextra -Werror -pedantic")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra -Werror -pedantic")
 endif (MSVC)
 
 ####

--- a/src/zip.c
+++ b/src/zip.c
@@ -1247,7 +1247,7 @@ static mz_int64 zip_file_move(MZ_FILE *m_pFile, mz_uint64 writen_num,
   if(move_buf == NULL){
     return -1;
   }
-  while (length >= page_size) {
+  while ((mz_int64)length >= page_size) {
     length -= page_size;
     if (file_move(m_pFile, writen_num, read_num, page_size, move_buf, page_size) != page_size) {
       CLEANUP(move_buf);
@@ -1258,13 +1258,13 @@ static mz_int64 zip_file_move(MZ_FILE *m_pFile, mz_uint64 writen_num,
   }
 
   if (length > 0) {
-    if (file_move(m_pFile, writen_num, read_num, length, move_buf, length) != length) {
+    if (file_move(m_pFile, writen_num, read_num, length, move_buf, length) != (mz_int64)length) {
       CLEANUP(move_buf);
       return -1;
     }
   }
   CLEANUP(move_buf);
-  return length;
+  return (mz_int64)length;
 }
 
 static int move_central_dir_entry(mz_zip_internal_state *pState, int begin,

--- a/src/zip.c
+++ b/src/zip.c
@@ -1115,19 +1115,28 @@ static mz_bool file_name_matches(const char *file_name,
   int file_name_length = strlen(file_name);
   int delete_name_length = strlen(delete_name);
   char *delete_entry_name = strrpl(delete_name, delete_name_length, '\\', '/');
+  if (!delete_entry_name) {
+    return MZ_FALSE;
+  }
 
   if (delete_name_length > file_name_length) {
+    CLEANUP(delete_entry_name);
     return MZ_FALSE;
   }
   if (delete_entry_name[delete_name_length - 1] == '/') {
     if (strncmp(file_name, delete_entry_name, delete_name_length) == 0) {
+      CLEANUP(delete_entry_name);
       return MZ_TRUE;
     }
+    CLEANUP(delete_entry_name);
     return MZ_FALSE;
   }
   if (strcmp(file_name, delete_entry_name) == 0) {
+    CLEANUP(delete_entry_name);
     return MZ_TRUE;
   }
+
+  CLEANUP(delete_entry_name);
   return MZ_FALSE;
 }
 

--- a/src/zip.c
+++ b/src/zip.c
@@ -1121,8 +1121,6 @@ static int init_entry_mark_array(struct zip_t *zip,
       entry_mark_array[i].type = KEEP;
     }
 
-    // CLEANUP(zip->entry.name);
-
     if (!mz_zip_reader_file_stat(&zip->archive, i, &file_stat)) {
       return -1;
     }

--- a/src/zip.c
+++ b/src/zip.c
@@ -1176,7 +1176,7 @@ static int mark_entry_mark_array(struct zip_t *zip,
   d_pos = entry_mark_array[index].m_local_header_ofs;
   entry_mark_array[index].type = DELETE;
 
-  mz_uint64 *local_header_ofs_array = (mz_uint64 *)calloc(n * sizeof(mz_uint64));
+  mz_uint64 *local_header_ofs_array = (mz_uint64 *)calloc(n, sizeof(mz_uint64));
   if(local_header_ofs_array == NULL){
     return -1;
   }
@@ -1194,7 +1194,7 @@ static int mark_entry_mark_array(struct zip_t *zip,
     entry_mark_array[i].file_index = new_index;
   }
 
-  mz_uint64 *length = (mz_uint64 *)calloc(n * sizeof(mz_uint64));
+  mz_uint64 *length = (mz_uint64 *)calloc(n, sizeof(mz_uint64));
   if(length == NULL){
     CLEANUP(local_header_ofs_array);
     return -1;
@@ -1243,7 +1243,7 @@ static mz_int64 file_move(MZ_FILE *m_pFile, const mz_uint64 to,
 static mz_int64 zip_file_move(MZ_FILE *m_pFile, mz_uint64 writen_num,
                               mz_uint64 read_num, mz_uint64 length) {
   const mz_int64 page_size = 1 << 12; // 4K
-  mz_uint8 *move_buf = (mz_uint8 *)calloc(page_size);
+  mz_uint8 *move_buf = (mz_uint8 *)calloc(1, page_size);
   if(move_buf == NULL){
     return -1;
   }
@@ -1364,7 +1364,7 @@ static int delete_central_dir_entrys(mz_zip_internal_state *pState,
 
 static int zip_entry_move(struct zip_t *zip,
                           struct entry_mark *entry_mark_array, int entry_num) {
-  mz_bool *deleted_entry_flag_array = (mz_bool *)calloc(entry_num * sizeof(mz_bool));
+  mz_bool *deleted_entry_flag_array = (mz_bool *)calloc(entry_num, sizeof(mz_bool));
   if(deleted_entry_flag_array == NULL){
     return -1;
   }
@@ -1436,7 +1436,7 @@ int zip_entry_delete(struct zip_t *zip, const char *name) {
     return -1;
   }
   int n = zip_total_entries(zip);
-  struct entry_mark *entry_mark_array = (struct entry_mark *)calloc(n * sizeof(struct entry_mark));
+  struct entry_mark *entry_mark_array = (struct entry_mark *)calloc(n, sizeof(struct entry_mark));
   if(entry_mark_array == NULL){
     return -1;
   }

--- a/src/zip.h
+++ b/src/zip.h
@@ -336,7 +336,7 @@ extern int zip_extract_stream(const char *stream, size_t size, const char *dir,
                               void *arg);
 
 /**
- * open zip archive stream into memory.
+ * Opens zip archive stream into memory.
  *
  * @param stream zip archive stream.
  * @param size stream size.
@@ -344,6 +344,16 @@ extern int zip_extract_stream(const char *stream, size_t size, const char *dir,
  * @return the zip archive handler or NULL on error
  */
 extern struct zip_t *zip_open_stream(const char *stream, size_t size);
+
+/**
+ * Deletes a zip archive file.
+ *
+ * @param zip zip archive handler.
+ * @param name zip archive file.
+ *
+ * @return the return code - 0 on success, negative number (< 0) on error.
+ */
+extern int zip_entry_delete(struct zip_t *zip, const char *name);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/zip.h
+++ b/src/zip.h
@@ -350,11 +350,11 @@ extern struct zip_t *zip_open_stream(const char *stream, size_t size);
  *
  * @param zip zip archive handler.
  * @param entries array of zip archive entries to be deleted.
- * @param num the number of entries to be deleted.
+ * @param len the number of entries to be deleted.
  * @return the number of deleted entries, or negative number (< 0) on error.
  */
-extern int zip_entries_delete(struct zip_t *zip, char *entries[],
-                              const int num);
+extern int zip_entries_delete(struct zip_t *zip, char *const entries[],
+                              size_t len);
 /** @} */
 #ifdef __cplusplus
 }

--- a/test/test.c
+++ b/test/test.c
@@ -574,6 +574,9 @@ static int creat_zip_file(const char *filename) {
   assert(0 == zip_entry_write(zip, WFILE, strlen(WFILE)));
   assert(0 == zip_entry_close(zip));
 
+  assert(0 == zip_entry_open(zip, "test1/"));
+  assert(0 == zip_entry_close(zip));
+
   assert(0 == zip_entry_open(zip, "test1/empty/"));
   assert(0 == zip_entry_close(zip));
 
@@ -584,7 +587,7 @@ static int creat_zip_file(const char *filename) {
   assert(0 == zip_entry_open(zip, "test/empty/"));
   assert(0 == zip_entry_close(zip));
 
-  assert(9 == zip_total_entries(zip));
+  assert(10 == zip_total_entries(zip));
   zip_close(zip);
   return 0;
 }
@@ -593,11 +596,12 @@ static void test_delete_entry() {
   remove(ZIPNAME);
   assert(0 == creat_zip_file(ZIPNAME));
   struct zip_t *zip = zip_open(ZIPNAME, 0, 'd');
-  assert(9 == zip_total_entries(zip));
+  assert(10 == zip_total_entries(zip));
   assert(1 == zip_entry_delete(zip, "test/test-1.txt"));
   assert(1 == zip_entry_delete(zip, "test\\test-3.txt"));
   assert(1 == zip_entry_delete(zip, "test/empty/"));
   assert(1 == zip_entry_delete(zip, "empty/"));
+  assert(1 == zip_entry_delete(zip, "test1/"));
   assert(5 == zip_total_entries(zip));
   zip_close(zip);
 
@@ -607,7 +611,7 @@ static void test_delete_entry() {
   assert(-1 == zip_entry_open(zip, "test/test-3.txt"));
   assert(-1 == zip_entry_open(zip, "test/empty/"));
   assert(-1 == zip_entry_open(zip, "empty/"));
-
+  assert(-1 == zip_entry_open(zip, "test1/"));
   char *buf = NULL;
   ssize_t bufsize;
 
@@ -669,14 +673,13 @@ static void test_delete_folder() {
   zip_close(zip);
 
   zip = zip_open(ZIPNAME, 0, 'd');
-  assert(9 == zip_total_entries(zip));
+  assert(10 == zip_total_entries(zip));
   assert(0 == zip_entry_delete(zip, "test"));
-  assert(6 == zip_entry_delete(zip, "test\\"));
-  assert(3 == zip_total_entries(zip));
+  assert(6 == zip_entry_delete(zip, "test\\*"));
+  assert(4 == zip_total_entries(zip));
   zip_close(zip);
 
   zip = zip_open(ZIPNAME, 0, 'r');
-
   assert(-1 == zip_entry_open(zip, "test/test-1.txt"));
   assert(-1 == zip_entry_open(zip, "test/test-2.txt"));
   assert(-1 == zip_entry_open(zip, "test/test-3.txt"));
@@ -686,6 +689,7 @@ static void test_delete_folder() {
 
   char *buf = NULL;
   ssize_t bufsize;
+  ;
   assert(0 == zip_entry_openbyindex(zip, 0));
   bufsize = zip_entry_read(zip, (void **)&buf, NULL);
   assert(strlen(TESTDATA1) == zip_entry_size(zip));
@@ -701,6 +705,11 @@ static void test_delete_folder() {
   assert(0 == zip_entry_close(zip));
 
   assert(0 == zip_entry_openbyindex(zip, 2));
+  assert(0 == zip_entry_size(zip));
+  assert(0 == strcmp(zip_entry_name(zip), "test1/"));
+  assert(0 == zip_entry_close(zip));
+
+  assert(0 == zip_entry_openbyindex(zip, 3));
   assert(0 == zip_entry_size(zip));
   assert(0 == strcmp(zip_entry_name(zip), "test1/empty/"));
   assert(0 == zip_entry_close(zip));

--- a/test/test.c
+++ b/test/test.c
@@ -547,6 +547,8 @@ static void test_open_stream(void) {
 #endif
 }
 
+#if defined(_WIN64) || defined(_WIN32) || defined(__WIN32__)
+#else
 static int create_zip_file(const char *filename) {
   struct zip_t *zip = zip_open(filename, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
   assert(zip != NULL);
@@ -579,8 +581,11 @@ static int create_zip_file(const char *filename) {
   zip_close(zip);
   return 0;
 }
+#endif
 
 static void test_entries_delete() {
+#if defined(_WIN64) || defined(_WIN32) || defined(__WIN32__)
+#else
   remove(ZIPNAME);
   assert(0 == create_zip_file(ZIPNAME));
 
@@ -630,6 +635,7 @@ static void test_entries_delete() {
   buf = NULL;
 
   zip_close(zip);
+#endif
 }
 
 int main(int argc, char *argv[]) {

--- a/test/test.c
+++ b/test/test.c
@@ -571,7 +571,11 @@ static int create_zip_file(const char *filename) {
   assert(0 == zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
   assert(0 == zip_entry_close(zip));
 
-  assert(5 == zip_total_entries(zip));
+  assert(0 == zip_entry_open(zip, "directory/file.4"));
+  assert(0 == zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+  assert(0 == zip_entry_close(zip));
+
+  assert(6 == zip_total_entries(zip));
   zip_close(zip);
   return 0;
 }
@@ -586,6 +590,7 @@ static void test_entries_delete() {
   assert(0 == zip_entry_open(zip, "directory/file.1"));
   assert(0 == zip_entry_open(zip, "otherdirectory/file.3"));
   assert(0 == zip_entry_open(zip, "directory/file.2"));
+  assert(0 == zip_entry_open(zip, "directory/file.4"));
   zip_close(zip);
 
   char *entries[] = {"file.txt", "a", "directory/file.1",
@@ -596,11 +601,28 @@ static void test_entries_delete() {
 
   zip = zip_open(ZIPNAME, 0, 'r');
   assert(-1 == zip_entry_open(zip, "file.txt"));
+  assert(0 == zip_entry_close(zip));
   assert(-1 == zip_entry_open(zip, "a"));
+  assert(0 == zip_entry_close(zip));
   assert(-1 == zip_entry_open(zip, "directory/file.1"));
+  assert(0 == zip_entry_close(zip));
   assert(-1 == zip_entry_open(zip, "otherdirectory/file.3"));
+  assert(0 == zip_entry_close(zip));
   assert(-1 == zip_entry_open(zip, "directory/file.2"));
-  assert(0 == zip_total_entries(zip));
+  assert(0 == zip_entry_close(zip));
+
+  assert(1 == zip_total_entries(zip));
+  assert(0 == zip_entry_open(zip, "directory/file.4"));
+  size_t buftmp = 0;
+  char *buf = NULL;
+  ssize_t bufsize = zip_entry_read(zip, (void **)&buf, &buftmp);
+  assert(bufsize == strlen(TESTDATA1));
+  assert((size_t)bufsize == buftmp);
+  assert(0 == strncmp(buf, TESTDATA1, bufsize));
+  assert(0 == zip_entry_close(zip));
+  free(buf);
+  buf = NULL;
+
   zip_close(zip);
 }
 

--- a/test/test.c
+++ b/test/test.c
@@ -610,7 +610,7 @@ static void test_delete_entry() {
   assert(-1 == zip_entry_open(zip, "test/test-3.txt"));
   assert(-1 == zip_entry_open(zip, "test/empty/"));
   assert(-1 == zip_entry_open(zip, "empty/"));
-  assert(-1 == zip_entry_open(zip, "test1/"));
+
   char *buf = NULL;
   ssize_t bufsize;
 

--- a/test/test.c
+++ b/test/test.c
@@ -586,11 +586,17 @@ static void test_entries_delete() {
 
   struct zip_t *zip = zip_open(ZIPNAME, 0, 'r');
   assert(0 == zip_entry_open(zip, "file.txt"));
+  assert(0 == zip_entry_close(zip));
   assert(0 == zip_entry_open(zip, "a"));
+  assert(0 == zip_entry_close(zip));
   assert(0 == zip_entry_open(zip, "directory/file.1"));
+  assert(0 == zip_entry_close(zip));
   assert(0 == zip_entry_open(zip, "otherdirectory/file.3"));
+  assert(0 == zip_entry_close(zip));
   assert(0 == zip_entry_open(zip, "directory/file.2"));
+  assert(0 == zip_entry_close(zip));
   assert(0 == zip_entry_open(zip, "directory/file.4"));
+  assert(0 == zip_entry_close(zip));
   zip_close(zip);
 
   char *entries[] = {"file.txt", "a", "directory/file.1",


### PR DESCRIPTION
@kuba-- 
I have implemented the entry deletion function. The idea is to obtain the offset and data length of every file data in the ZIP file first, then move the data behind the deleted entry forward to overwrite the deleted data, and in the  end truncate the invalid data at the end of the ZIP file. The case of deleting one folder (multiple files) at a time is considered in the implementation.