### PR TITLE
fix compilation error for msvs latest

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -66,6 +66,10 @@
     }                                                                          \
   } while (0)
 
+#ifdef _WIN32
+#define fileno _fileno
+#endif
+
 static int file_truncate(mz_zip_archive *pZip) {
   mz_zip_internal_state *pState = pZip->m_pState;
   mz_uint64 file_size = pZip->m_archive_size;

--- a/src/zip.c
+++ b/src/zip.c
@@ -39,12 +39,13 @@
 #include <unistd.h>
 #endif
 
-#ifdef _MSC_VER
-#define ftruncate(fd, sz) (-(_chsize_s((fd), (__int64)(sz)) != 0))
-#endif
-
 #include "miniz.h"
 #include "zip.h"
+
+#ifdef _MSC_VER
+#define ftruncate(fd, sz) (-(_chsize_s((fd), (__int64)(sz)) != 0))
+#define fileno _fileno
+#endif
 
 #ifndef HAS_DEVICE
 #define HAS_DEVICE(P) 0
@@ -65,10 +66,6 @@
       ptr = NULL;                                                              \
     }                                                                          \
   } while (0)
-
-#ifdef _WIN32
-#define fileno _fileno
-#endif
 
 static int file_truncate(mz_zip_archive *pZip) {
   mz_zip_internal_state *pState = pZip->m_pState;


### PR DESCRIPTION
When building with visual studio with `Preview - Features from the Latest C++ Working Draft (std:c++latest)` we get the following error
![image](https://user-images.githubusercontent.com/17161067/102364109-c7010100-3fbe-11eb-9831-5848f0edc7d6.png)

I hope it does not create issues for other windows compilers.