### PR TITLE
docs: fix simple typo, purpsosely -> purposely

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -400,7 +400,7 @@ typedef enum {
 #ifndef MINIZ_NO_ZLIB_APIS
 
 // Heap allocation callbacks.
-// Note that mz_alloc_func parameter types purpsosely differ from zlib's:
+// Note that mz_alloc_func parameter types purposely differ from zlib's:
 // items/size is size_t, not unsigned long.
 typedef void *(*mz_alloc_func)(void *opaque, size_t items, size_t size);
 typedef void (*mz_free_func)(void *opaque, void *address);


### PR DESCRIPTION
There is a small typo in src/miniz.h.

Should read `purposely` rather than `purpsosely`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md