### PR TITLE
Exports symbols of API and hides others symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run:  cmake -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE .
+      run:  cmake .
     - name: Build
       run: |
         cmake --build . --config "Debug"
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run:  cmake -G "MinGW Makefiles" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE .
+      run:  cmake -G "MinGW Makefiles" .
     - name: Build
       run: |
         mingw32-make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,27 +8,25 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 option(CMAKE_DISABLE_TESTING "Disable test creation" OFF)
 option(ZIP_STATIC_PIC "Build static zip with PIC" ON)
 
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
 # zip
 set(SRC src/miniz.h src/zip.h src/zip.c)
 
-# this is the "object library" target: compiles the sources only once
-add_library(OBJLIB OBJECT ${SRC})
-# shared libraries need PIC
-if(BUILD_SHARED_LIBS OR ZIP_STATIC_PIC)
-  set_property(TARGET OBJLIB PROPERTY POSITION_INDEPENDENT_CODE 1)
+add_library(${PROJECT_NAME} ${SRC})
+
+if(ZIP_STATIC_PIC)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE 1)
 endif()
 
-# static and shared libraries built from the same object files
-if (BUILD_SHARED_LIBS)
-  add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:OBJLIB>)
-  include(GenerateExportHeader)
-  generate_export_header(${PROJECT_NAME})
-else()
-  add_library(${PROJECT_NAME} STATIC $<TARGET_OBJECTS:OBJLIB>)
-endif()
+set(ZIP_EXPORT_HEADER "${GENERATED_DIR}/zip/zip_export.h")
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${ZIP_EXPORT_HEADER})
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_VISIBILITY_PRESET hidden)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${GENERATED_DIR}>
   $<INSTALL_INTERFACE:include>
 )
 
@@ -56,8 +54,6 @@ endif (MSVC)
 
 set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
 set(INCLUDE_INSTALL_DIR "include")
-
-set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 # Configuration
 set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
@@ -102,7 +98,8 @@ install(TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION lib
         INCLUDES DESTINATION ${INCLUDE_INSTALL_DIR}
 )
-install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h DESTINATION ${INCLUDE_INSTALL_DIR}/zip)
+install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h ${ZIP_EXPORT_HEADER}
+        DESTINATION ${INCLUDE_INSTALL_DIR}/zip)
 
 # uninstall target (https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake)
 if(NOT TARGET uninstall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 if (NOT CMAKE_DISABLE_TESTING)
   enable_testing()
   add_subdirectory(test)
-  find_package(Sanitizers)
-  add_sanitizers(${PROJECT_NAME} ${test_out})
 endif()
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 option(CMAKE_DISABLE_TESTING "Disable test creation" OFF)
 option(ZIP_STATIC_PIC "Build static zip with PIC" ON)
 
-set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
 # zip
 set(SRC src/miniz.h src/zip.h src/zip.c)
 
@@ -19,14 +17,16 @@ if(ZIP_STATIC_PIC)
   set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE 1)
 endif()
 
-set(ZIP_EXPORT_HEADER "${GENERATED_DIR}/zip/zip_export.h")
-include(GenerateExportHeader)
-generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${ZIP_EXPORT_HEADER})
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_VISIBILITY_PRESET hidden)
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(${PROJECT_NAME}
+    PUBLIC ZIP_SHARED
+    PRIVATE ZIP_BUILD_SHARED
+  )
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-  $<BUILD_INTERFACE:${GENERATED_DIR}>
   $<INSTALL_INTERFACE:include>
 )
 
@@ -52,6 +52,8 @@ endif (MSVC)
 
 set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
 set(INCLUDE_INSTALL_DIR "include")
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 # Configuration
 set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
@@ -96,8 +98,7 @@ install(TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION lib
         INCLUDES DESTINATION ${INCLUDE_INSTALL_DIR}
 )
-install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h ${ZIP_EXPORT_HEADER}
-        DESTINATION ${INCLUDE_INSTALL_DIR}/zip)
+install(FILES ${PROJECT_SOURCE_DIR}/src/zip.h DESTINATION ${INCLUDE_INSTALL_DIR}/zip)
 
 # uninstall target (https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake)
 if(NOT TARGET uninstall)

--- a/src/zip.h
+++ b/src/zip.h
@@ -12,10 +12,22 @@
 #ifndef ZIP_H
 #define ZIP_H
 
-#include <zip/zip_export.h>
-
 #include <string.h>
 #include <sys/types.h>
+
+#ifndef ZIP_SHARED
+#  define ZIP_EXPORT
+#else
+#  ifdef _WIN32
+#    ifdef ZIP_BUILD_SHARED
+#      define ZIP_EXPORT __declspec(dllexport)
+#    else
+#      define ZIP_EXPORT __declspec(dllimport)
+#    endif
+#  else
+#    define ZIP_EXPORT __attribute__ ((visibility ("default")))
+#  endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/zip.h
+++ b/src/zip.h
@@ -12,6 +12,8 @@
 #ifndef ZIP_H
 #define ZIP_H
 
+#include <zip/zip_export.h>
+
 #include <string.h>
 #include <sys/types.h>
 
@@ -88,7 +90,7 @@ typedef long ssize_t; /* byte count or error */
  * @return error message string coresponding to errnum or NULL if error is not
  * found.
  */
-extern const char *zip_strerror(int errnum);
+extern ZIP_EXPORT const char *zip_strerror(int errnum);
 
 /**
  * @struct zip_t
@@ -110,14 +112,15 @@ struct zip_t;
  *
  * @return the zip archive handler or NULL on error
  */
-extern struct zip_t *zip_open(const char *zipname, int level, char mode);
+extern ZIP_EXPORT struct zip_t *zip_open(const char *zipname, int level,
+                                         char mode);
 
 /**
  * Closes the zip archive, releases resources - always finalize.
  *
  * @param zip zip archive handler.
  */
-extern void zip_close(struct zip_t *zip);
+extern ZIP_EXPORT void zip_close(struct zip_t *zip);
 
 /**
  * Determines if the archive has a zip64 end of central directory headers.
@@ -127,7 +130,7 @@ extern void zip_close(struct zip_t *zip);
  * @return the return code - 1 (true), 0 (false), negative number (< 0) on
  *         error.
  */
-extern int zip_is64(struct zip_t *zip);
+extern ZIP_EXPORT int zip_is64(struct zip_t *zip);
 
 /**
  * Opens an entry by name in the zip archive.
@@ -141,7 +144,7 @@ extern int zip_is64(struct zip_t *zip);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_open(struct zip_t *zip, const char *entryname);
+extern ZIP_EXPORT int zip_entry_open(struct zip_t *zip, const char *entryname);
 
 /**
  * Opens a new entry by index in the zip archive.
@@ -153,7 +156,7 @@ extern int zip_entry_open(struct zip_t *zip, const char *entryname);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_openbyindex(struct zip_t *zip, int index);
+extern ZIP_EXPORT int zip_entry_openbyindex(struct zip_t *zip, int index);
 
 /**
  * Closes a zip entry, flushes buffer and releases resources.
@@ -162,7 +165,7 @@ extern int zip_entry_openbyindex(struct zip_t *zip, int index);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_close(struct zip_t *zip);
+extern ZIP_EXPORT int zip_entry_close(struct zip_t *zip);
 
 /**
  * Returns a local name of the current zip entry.
@@ -178,7 +181,7 @@ extern int zip_entry_close(struct zip_t *zip);
  *
  * @return the pointer to the current zip entry name, or NULL on error.
  */
-extern const char *zip_entry_name(struct zip_t *zip);
+extern ZIP_EXPORT const char *zip_entry_name(struct zip_t *zip);
 
 /**
  * Returns an index of the current zip entry.
@@ -187,7 +190,7 @@ extern const char *zip_entry_name(struct zip_t *zip);
  *
  * @return the index on success, negative number (< 0) on error.
  */
-extern int zip_entry_index(struct zip_t *zip);
+extern ZIP_EXPORT int zip_entry_index(struct zip_t *zip);
 
 /**
  * Determines if the current zip entry is a directory entry.
@@ -197,7 +200,7 @@ extern int zip_entry_index(struct zip_t *zip);
  * @return the return code - 1 (true), 0 (false), negative number (< 0) on
  *         error.
  */
-extern int zip_entry_isdir(struct zip_t *zip);
+extern ZIP_EXPORT int zip_entry_isdir(struct zip_t *zip);
 
 /**
  * Returns an uncompressed size of the current zip entry.
@@ -206,7 +209,7 @@ extern int zip_entry_isdir(struct zip_t *zip);
  *
  * @return the uncompressed size in bytes.
  */
-extern unsigned long long zip_entry_size(struct zip_t *zip);
+extern ZIP_EXPORT unsigned long long zip_entry_size(struct zip_t *zip);
 
 /**
  * Returns CRC-32 checksum of the current zip entry.
@@ -215,7 +218,7 @@ extern unsigned long long zip_entry_size(struct zip_t *zip);
  *
  * @return the CRC-32 checksum.
  */
-extern unsigned int zip_entry_crc32(struct zip_t *zip);
+extern ZIP_EXPORT unsigned int zip_entry_crc32(struct zip_t *zip);
 
 /**
  * Compresses an input buffer for the current zip entry.
@@ -226,7 +229,8 @@ extern unsigned int zip_entry_crc32(struct zip_t *zip);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize);
+extern ZIP_EXPORT int zip_entry_write(struct zip_t *zip, const void *buf,
+                                      size_t bufsize);
 
 /**
  * Compresses a file for the current zip entry.
@@ -236,7 +240,7 @@ extern int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_fwrite(struct zip_t *zip, const char *filename);
+extern ZIP_EXPORT int zip_entry_fwrite(struct zip_t *zip, const char *filename);
 
 /**
  * Extracts the current zip entry into output buffer.
@@ -253,7 +257,8 @@ extern int zip_entry_fwrite(struct zip_t *zip, const char *filename);
  * @return the return code - the number of bytes actually read on success.
  *         Otherwise a -1 on error.
  */
-extern ssize_t zip_entry_read(struct zip_t *zip, void **buf, size_t *bufsize);
+extern ZIP_EXPORT ssize_t zip_entry_read(struct zip_t *zip, void **buf,
+                                         size_t *bufsize);
 
 /**
  * Extracts the current zip entry into a memory buffer using no memory
@@ -271,8 +276,8 @@ extern ssize_t zip_entry_read(struct zip_t *zip, void **buf, size_t *bufsize);
  * @return the return code - the number of bytes actually read on success.
  *         Otherwise a -1 on error (e.g. bufsize is not large enough).
  */
-extern ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf,
-                                     size_t bufsize);
+extern ZIP_EXPORT ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf,
+                                                size_t bufsize);
 
 /**
  * Extracts the current zip entry into output file.
@@ -282,7 +287,7 @@ extern ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf,
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_entry_fread(struct zip_t *zip, const char *filename);
+extern ZIP_EXPORT int zip_entry_fread(struct zip_t *zip, const char *filename);
 
 /**
  * Extracts the current zip entry using a callback function (on_extract).
@@ -294,7 +299,7 @@ extern int zip_entry_fread(struct zip_t *zip, const char *filename);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int
+extern ZIP_EXPORT int
 zip_entry_extract(struct zip_t *zip,
                   size_t (*on_extract)(void *arg, unsigned long long offset,
                                        const void *data, size_t size),
@@ -308,7 +313,7 @@ zip_entry_extract(struct zip_t *zip,
  * @return the return code - the number of entries on success, negative number
  *         (< 0) on error.
  */
-extern int zip_entries_total(struct zip_t *zip);
+extern ZIP_EXPORT int zip_entries_total(struct zip_t *zip);
 
 /**
  * Deletes zip archive entries.
@@ -318,8 +323,8 @@ extern int zip_entries_total(struct zip_t *zip);
  * @param len the number of entries to be deleted.
  * @return the number of deleted entries, or negative number (< 0) on error.
  */
-extern int zip_entries_delete(struct zip_t *zip, char *const entries[],
-                              size_t len);
+extern ZIP_EXPORT int zip_entries_delete(struct zip_t *zip,
+                                         char *const entries[], size_t len);
 
 /**
  * Extracts a zip archive stream into directory.
@@ -338,10 +343,10 @@ extern int zip_entries_delete(struct zip_t *zip, char *const entries[],
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_stream_extract(const char *stream, size_t size, const char *dir,
-                              int (*on_extract)(const char *filename,
-                                                void *arg),
-                              void *arg);
+extern ZIP_EXPORT int
+zip_stream_extract(const char *stream, size_t size, const char *dir,
+                   int (*on_extract)(const char *filename, void *arg),
+                   void *arg);
 
 /**
  * Opens zip archive stream into memory.
@@ -351,8 +356,8 @@ extern int zip_stream_extract(const char *stream, size_t size, const char *dir,
  *
  * @return the zip archive handler or NULL on error
  */
-extern struct zip_t *zip_stream_open(const char *stream, size_t size, int level,
-                                     char mode);
+extern ZIP_EXPORT struct zip_t *zip_stream_open(const char *stream, size_t size,
+                                                int level, char mode);
 
 /**
  * Copy zip archive stream output buffer.
@@ -363,7 +368,8 @@ extern struct zip_t *zip_stream_open(const char *stream, size_t size, int level,
  *
  * @return copy size
  */
-extern ssize_t zip_stream_copy(struct zip_t *zip, void **buf, ssize_t *bufsize);
+extern ZIP_EXPORT ssize_t zip_stream_copy(struct zip_t *zip, void **buf,
+                                          ssize_t *bufsize);
 
 /**
  * Close zip archive releases resources.
@@ -372,7 +378,7 @@ extern ssize_t zip_stream_copy(struct zip_t *zip, void **buf, ssize_t *bufsize);
  *
  * @return
  */
-extern void zip_stream_close(struct zip_t *zip);
+extern ZIP_EXPORT void zip_stream_close(struct zip_t *zip);
 
 /**
  * Creates a new archive and puts files into a single zip archive.
@@ -383,7 +389,8 @@ extern void zip_stream_close(struct zip_t *zip);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_create(const char *zipname, const char *filenames[], size_t len);
+extern ZIP_EXPORT int zip_create(const char *zipname, const char *filenames[],
+                                 size_t len);
 
 /**
  * Extracts a zip archive file into directory.
@@ -401,9 +408,10 @@ extern int zip_create(const char *zipname, const char *filenames[], size_t len);
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
  */
-extern int zip_extract(const char *zipname, const char *dir,
-                       int (*on_extract_entry)(const char *filename, void *arg),
-                       void *arg);
+extern ZIP_EXPORT int zip_extract(const char *zipname, const char *dir,
+                                  int (*on_extract_entry)(const char *filename,
+                                                          void *arg),
+                                  void *arg);
 
 /** @} */
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,38 +1,40 @@
 cmake_minimum_required(VERSION 3.4)
 
+find_package(Sanitizers)
+
 # tests
 set(test_write_out test_write.out)
 add_executable(${test_write_out} test_write.c)
 target_link_libraries(${test_write_out} zip)
 add_test(NAME ${test_write_out} COMMAND ${test_write_out})
-set(test_write_out ${test_write_out} PARENT_SCOPE)
+add_sanitizers(${test_write_out})
 
 set(test_append_out test_append.out)
 add_executable(${test_append_out} test_append.c)
 target_link_libraries(${test_append_out} zip)
 add_test(NAME ${test_append_out} COMMAND ${test_append_out})
-set(test_append_out ${test_append_out} PARENT_SCOPE)
+add_sanitizers(${test_append_out})
 
 set(test_read_out test_read.out)
 add_executable(${test_read_out} test_read.c)
 target_link_libraries(${test_read_out} zip)
 add_test(NAME ${test_read_out} COMMAND ${test_read_out})
-set(test_read_out ${test_read_out} PARENT_SCOPE)
+add_sanitizers(${test_read_out})
 
 set(test_extract_out test_extract.out)
 add_executable(${test_extract_out} test_extract.c)
 target_link_libraries(${test_extract_out} zip)
 add_test(NAME ${test_extract_out} COMMAND ${test_extract_out})
-set(test_extract_out ${test_extract_out} PARENT_SCOPE)
+add_sanitizers(${test_extract_out})
 
 set(test_entry_out test_entry.out)
 add_executable(${test_entry_out} test_entry.c)
 target_link_libraries(${test_entry_out} zip)
 add_test(NAME ${test_entry_out} COMMAND ${test_entry_out})
-set(test_entry_out ${test_entry_out} PARENT_SCOPE)
+add_sanitizers(${test_entry_out})
 
 set(test_permissions_out test_permissions.out)
 add_executable(${test_permissions_out} test_permissions.c)
 target_link_libraries(${test_permissions_out} zip)
 add_test(NAME ${test_permissions_out} COMMAND ${test_permissions_out})
-set(test_permissions_out ${test_permissions_out} PARENT_SCOPE)
+add_sanitizers(${test_permissions_out})


### PR DESCRIPTION
It results in cleaner shared libs for non-msvc builds, and avoid to use CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS for Visual Studio (it was useless for MinGW by the way).