### PR TITLE
Fix MSVC C2440 pointer cast error

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4119,7 +4119,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h,
 
 static wchar_t *str2wstr(const char *str) {
   int len = strlen(str) + 1;
-  wchar_t *wstr = malloc(len * sizeof(wchar_t));
+  wchar_t *wstr = (wchar_t*)malloc(len * sizeof(wchar_t));
   MultiByteToWideChar(CP_UTF8, 0, str, len * sizeof(char), wstr, len);
   return wstr;
 }


### PR DESCRIPTION
In miniz.h in the str2wstr function, the malloc result hasn't been casted to wchar_t* which results in a C2440 compiler error on MSVC :)