### PR TITLE
Updated README: fixed example: size_t -> ssize_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ free(outbuf);
 
 ```c
 char *buf = NULL;
-ssize_t bufsize = 0;
+size_t bufsize = 0;
 
 struct zip_t *zip = zip_stream_open(zipstream, zipstreamsize, 0, 'r');
 {


### PR DESCRIPTION
That fixes the next gcc error:
```
error: no matching function for call to 'zip_stream_copy'
zip.h:383:27: note: candidate function not viable: no known conversion from 'size_t *' (aka 'unsigned long *') to 'ssize_t *' (aka 'long *') for 3rd argument
```