### PR TITLE
Port of features from miniz (creation of ZIP64 files and empty folders)

### DIFF
--- a/test/test_read.c
+++ b/test/test_read.c
@@ -49,7 +49,7 @@ MU_TEST(test_read) {
 
   struct zip_t *zip = zip_open(ZIPNAME, 0, 'r');
   mu_check(zip != NULL);
-  mu_assert_int_eq(0, zip_is64(zip));
+  mu_assert_int_eq(1, zip_is64(zip));
 
   mu_assert_int_eq(0, zip_entry_open(zip, "test\\test-1.txt"));
   mu_assert_int_eq(strlen(TESTDATA1), zip_entry_size(zip));
@@ -88,7 +88,7 @@ MU_TEST(test_noallocread) {
 
   struct zip_t *zip = zip_open(ZIPNAME, 0, 'r');
   mu_check(zip != NULL);
-  mu_assert_int_eq(0, zip_is64(zip));
+  mu_assert_int_eq(1, zip_is64(zip));
 
   mu_assert_int_eq(0, zip_entry_open(zip, "test/test-2.txt"));
   bufsize = zip_entry_noallocread(zip, (void *)buf, buftmp);

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -36,7 +36,7 @@ MU_TEST(test_write) {
   mu_check(CRC32DATA1 == zip_entry_crc32(zip));
   mu_assert_int_eq(0, zip_entry_close(zip));
 
-  mu_assert_int_eq(0, zip_is64(zip));
+  mu_assert_int_eq(1, zip_is64(zip));
 
   zip_close(zip);
 }
@@ -62,7 +62,7 @@ MU_TEST(test_fwrite) {
   mu_assert_int_eq(0, zip_entry_open(zip, WFILE));
   mu_assert_int_eq(0, zip_entry_fwrite(zip, WFILE));
   mu_assert_int_eq(0, zip_entry_close(zip));
-  mu_assert_int_eq(0, zip_is64(zip));
+  mu_assert_int_eq(1, zip_is64(zip));
 
   zip_close(zip);
 }


### PR DESCRIPTION
Hello.

This pull request is a port of features from miniz that our company required for our usage of this library (many thanks for releasing it!). I think that they could be also useful to others, so here is a pull request for your consideration.

The code modified has been almost directly ported from this file:
https://github.com/richgel999/miniz/blob/master/miniz_zip.c
 
with minor changes to adapt the code to this project and simplify the port.
 
There are some points that I think that deserve to be commented:
a) This pull request makes the library to always create ZIP64 files
This has been forced with the flag `MZ_ZIP_FLAG_WRITE_ZIP64` and has being done this way because the interface of the library doesn't require to know the number of files to ZIP or their size in advance (so initially we don't know if ZIP64 will be needed), and also because it eases the implementation.

b) Data descriptors (metadata after compressed data) are used to specify uncompresed size, compressed size and CRC
This is done using the flag MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR and it avoids the call to fseek that was needed to rewrite the header. This is optional in miniz. I have used this approach mainly because it allows to use the library in applications that doesn't have a working fseek like in our case, where we hook fopen, fwrite... to send out the data in streaming.

c) Empty folders are created calling `zip_entry_open` with a path ending with `/` followed by a call to `zip_entry_close`.
miniz just checks if the path ends with `/` to add the attribute `MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG` and throws an error if any data has been written, but I have added an extra check to not add the attribute if data has been written, to keep a better backwards compatibility with the current version of this library.

I have tested the changes creating a ZIP with 500.000 little files, another one with a file bigger than 5GB, and others with few files of different sizes and empty folders. I have been able to extract them on Linux, Windows and Mac with common tools on each platform (Nautilus, File Roller, WinRAR, and built-in decompressors) without problems.