### PR TITLE
Add switch case for MZ_ZIP_TOTAL_ERRORS

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -10016,6 +10016,8 @@ const char *mz_zip_get_error_string(mz_zip_error mz_err) {
     return "validation failed";
   case MZ_ZIP_WRITE_CALLBACK_FAILED:
     return "write calledback failed";
+  case MZ_ZIP_TOTAL_ERRORS:
+    return "total errors";
   default:
     break;
   }


### PR DESCRIPTION
As per comment in https://github.com/kuba--/zip/blob/a597bdf814684a5a8b4adbae8597f03c865601fd/src/miniz.h#L1250
Fix compiling with `-Werror=switch-enum`.