### PR TITLE
Port to MSVC 6.0

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4883,7 +4883,6 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   free(wPath);
   free(wMode);
 
-
 #if defined(ZIP_ENABLE_SHARABLE_FILE_OPEN) || _MSCVER <= 1200
 #else
   if (res) {
@@ -4894,13 +4893,11 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   return pFile;
 }
 
-
-static int mz_stat(
-        const char *pPath,
+static int mz_stat(const char *pPath,
 #if _MSV_VER > 1200
-        struct _stat64 *buffer
+                   struct _stat64 *buffer
 #else
-        struct _stati64 *buffer
+                   struct _stati64 *buffer
 #endif
 ) {
   wchar_t *wPath = str2wstr(pPath);
@@ -5293,7 +5290,8 @@ static MZ_TIME_T mz_zip_dos_to_time_t(int dos_time, int dos_date) {
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
 static void mz_zip_time_t_to_dos_time(MZ_TIME_T time, mz_uint16 *pDOS_time,
                                       mz_uint16 *pDOS_date) {
-#if defined(_MSC_VER) && _MSC_VER > 1200 /* MSVC 6.0 does not have localtime_s (and errno_t) */
+#if defined(_MSC_VER) &&                                                       \
+    _MSC_VER > 1200 /* MSVC 6.0 does not have localtime_s (and errno_t) */
   struct tm tm_struct;
   struct tm *tm = &tm_struct;
   errno_t err = localtime_s(tm, &time);

--- a/src/miniz.h
+++ b/src/miniz.h
@@ -574,7 +574,22 @@ typedef void *const voidpc;
 
 #pragma once
 #include <assert.h>
+
+#if _MSC_VER <= 1200
+// no stdint with MSVC 6.0, so work around it
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+
+#else
 #include <stdint.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -586,6 +601,7 @@ typedef unsigned int mz_uint32;
 typedef unsigned int mz_uint;
 typedef int64_t mz_int64;
 typedef uint64_t mz_uint64;
+
 typedef int mz_bool;
 
 #define MZ_FALSE (0)
@@ -4395,7 +4411,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r,
               tree_cur = pTable->m_tree[-tree_cur - 1];
           }
           tree_cur -= ((rev_code >>= 1) & 1);
-          (void)rev_code; // unused
+          (void)rev_code; /* unused */
           pTable->m_tree[-tree_cur - 1] = (mz_int16)sym_index;
         }
         if (r->m_type == 2) {
@@ -4840,7 +4856,7 @@ static FILE *mz_fopen(const char *pFilename, const char *pMode) {
   wchar_t *wFilename = str2wstr(pFilename);
   wchar_t *wMode = str2wstr(pMode);
 
-#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+#if defined(ZIP_ENABLE_SHARABLE_FILE_OPEN) || _MSCVER <= 1200
   pFile = _wfopen(wFilename, wMode);
 #else
   _wfopen_s(&pFile, wFilename, wMode);
@@ -4858,7 +4874,7 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   wchar_t *wPath = str2wstr(pPath);
   wchar_t *wMode = str2wstr(pMode);
 
-#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+#if defined(ZIP_ENABLE_SHARABLE_FILE_OPEN) || _MSCVER <= 1200
   pFile = _wfreopen(wPath, wMode, pStream);
 #else
   res = _wfreopen_s(&pFile, wPath, wMode, pStream);
@@ -4867,7 +4883,9 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   free(wPath);
   free(wMode);
 
-#ifndef ZIP_ENABLE_SHARABLE_FILE_OPEN
+
+#if defined(ZIP_ENABLE_SHARABLE_FILE_OPEN) || _MSCVER <= 1200
+#else
   if (res) {
     return NULL;
   }
@@ -4876,9 +4894,21 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   return pFile;
 }
 
-static int mz_stat(const char *pPath, struct _stat64 *buffer) {
+
+static int mz_stat(
+        const char *pPath,
+#if _MSV_VER > 1200
+        struct _stat64 *buffer
+#else
+        struct _stati64 *buffer
+#endif
+) {
   wchar_t *wPath = str2wstr(pPath);
+#if _MSV_VER > 1200
   int res = _wstat64(wPath, buffer);
+#else
+  int res = _wstati64(wPath, buffer);
+#endif
 
   free(wPath);
 
@@ -4898,9 +4928,21 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_FCLOSE fclose
 #define MZ_FREAD fread
 #define MZ_FWRITE fwrite
+
+#if _MSV_VER > 1200
+
 #define MZ_FTELL64 _ftelli64
 #define MZ_FSEEK64 _fseeki64
 #define MZ_FILE_STAT_STRUCT _stat64
+
+#else
+
+#define MZ_FTELL64 ftell // there is _telli64 but no _ftelli64, like WTF???
+#define MZ_FSEEK64 fseek
+#define MZ_FILE_STAT_STRUCT _stati64
+
+#endif
+
 #define MZ_FILE_STAT mz_stat
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN mz_freopen
@@ -5009,9 +5051,9 @@ static int mz_mkdir(const char *pDirname) {
 #endif /* #ifdef MINIZ_NO_STDIO */
 
 #ifndef CHMOD
-// Upon successful completion, a value of 0 is returned.
-// Otherwise, a value of -1 is returned and errno is set to indicate the error.
-// int chmod(const char *path, mode_t mode);
+/* Upon successful completion, a value of 0 is returned.
+ * Otherwise, a value of -1 is returned and errno is set to indicate the error.
+ * int chmod(const char *path, mode_t mode); */
 #define CHMOD(f, m) chmod(f, m)
 #endif
 
@@ -5251,7 +5293,7 @@ static MZ_TIME_T mz_zip_dos_to_time_t(int dos_time, int dos_date) {
 #ifndef MINIZ_NO_ARCHIVE_WRITING_APIS
 static void mz_zip_time_t_to_dos_time(MZ_TIME_T time, mz_uint16 *pDOS_time,
                                       mz_uint16 *pDOS_date) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER > 1200 /* MSVC 6.0 does not have localtime_s (and errno_t) */
   struct tm tm_struct;
   struct tm *tm = &tm_struct;
   errno_t err = localtime_s(tm, &time);
@@ -6278,10 +6320,10 @@ static mz_bool mz_zip_file_stat_internal(mz_zip_archive *pZip,
 
             pStat->m_local_header_ofs = MZ_READ_LE64(pField_data);
             pField_data += sizeof(mz_uint64);
-            (void)pField_data; // unused
+            (void)pField_data; /* unused */
 
             field_data_remaining -= sizeof(mz_uint64);
-            (void)field_data_remaining; // unused
+            (void)field_data_remaining; /* unused */
           }
 
           break;

--- a/src/miniz.h
+++ b/src/miniz.h
@@ -575,7 +575,7 @@ typedef void *const voidpc;
 #pragma once
 #include <assert.h>
 
-#if _MSC_VER <= 1200
+#if defined(_MSC_VER) && _MSC_VER <= 1200
 // no stdint with MSVC 6.0, so work around it
 typedef signed __int8 int8_t;
 typedef unsigned __int8 uint8_t;

--- a/src/zip.c
+++ b/src/zip.c
@@ -26,7 +26,7 @@
 
 #else
 
-#include <unistd.h> // needed for symlink()
+#include <unistd.h> /* needed for symlink() */
 #define STRCLONE(STR) ((STR) ? strdup(STR) : NULL)
 
 #endif
@@ -42,7 +42,11 @@
 #ifdef _MSC_VER
 #include <io.h>
 
+#if _MSC_VER > 1200
 #define ftruncate(fd, sz) (-(_chsize_s((fd), (sz)) != 0))
+#else
+#define ftruncate(fd, sz) (-(_chsize((fd), (sz)) != 0))
+#endif
 #define fileno _fileno
 #endif
 
@@ -178,7 +182,7 @@ static int zip_mkpath(char *path) {
 
   memset(npath, 0, MAX_PATH + 1);
   if (has_device) {
-    // only on windows
+    /* only on windows */
     npath[0] = path[0];
     npath[1] = path[1];
     len = 2;
@@ -231,7 +235,7 @@ static char *zip_name_normalize(char *name, char *const nname, size_t len) {
   if (name == NULL || nname == NULL || len <= 0) {
     return NULL;
   }
-  // skip trailing '/'
+  /*  skip trailing '/' */
   while (ISSLASH(*name))
     name++;
 
@@ -240,7 +244,7 @@ static char *zip_name_normalize(char *name, char *const nname, size_t len) {
       if (ncpy > 0 && strcmp(&nname[offnn], ".\0") &&
           strcmp(&nname[offnn], "..\0")) {
         offnn += ncpy;
-        nname[offnn++] = name[offn]; // append '/'
+        nname[offnn++] = name[offn]; /*  append '/' */
       }
       ncpy = 0;
     } else {
@@ -249,7 +253,7 @@ static char *zip_name_normalize(char *name, char *const nname, size_t len) {
     }
   }
 
-  // at the end, extra check what we've already copied
+  /*  at the end, extra check what we've already copied */
   if (ncpy == 0 || !strcmp(&nname[offnn], ".\0") ||
       !strcmp(&nname[offnn], "..\0")) {
     nname[offnn] = 0;
@@ -259,6 +263,7 @@ static char *zip_name_normalize(char *name, char *const nname, size_t len) {
 
 static mz_bool zip_name_match(const char *name1, const char *name2) {
   char *nname2 = NULL;
+  mz_bool res;
 
 #ifdef ZIP_RAW_ENTRYNAME
   nname2 = STRCLONE(name2);
@@ -270,7 +275,7 @@ static mz_bool zip_name_match(const char *name1, const char *name2) {
     return MZ_FALSE;
   }
 
-  mz_bool res = (strcmp(name1, nname2) == 0) ? MZ_TRUE : MZ_FALSE;
+  res = (strcmp(name1, nname2) == 0) ? MZ_TRUE : MZ_FALSE;
   CLEANUP(nname2);
   return res;
 }
@@ -312,7 +317,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
 
   memset((void *)&info, 0, sizeof(mz_zip_archive_file_stat));
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER > 1200
   strcpy_s(path, MAX_PATH, dir);
 #else
   strcpy(path, dir);
@@ -327,22 +332,22 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
     ++dirlen;
   }
 
-  // Get and print information about each file in the archive.
+  /*  Get and print information about each file in the archive. */
   n = mz_zip_reader_get_num_files(zip_archive);
   for (i = 0; i < n; ++i) {
     if (!mz_zip_reader_file_stat(zip_archive, i, &info)) {
-      // Cannot get information about zip archive;
+      /*  Cannot get information about zip archive; */
       err = ZIP_ENOENT;
       goto out;
     }
 
     if (!zip_name_normalize(info.m_filename, info.m_filename,
                             strlen(info.m_filename))) {
-      // Cannot normalize file name;
+      /*  Cannot normalize file name; */
       err = ZIP_EINVENTNAME;
       goto out;
     }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER > 1200
     strncpy_s(&path[dirlen], MAX_PATH - dirlen, info.m_filename,
               MAX_PATH - dirlen);
 #else
@@ -350,17 +355,17 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
 #endif
     err = zip_mkpath(path);
     if (err < 0) {
-      // Cannot make a path
+      /*  Cannot make a path */
       goto out;
     }
 
     if ((((info.m_version_made_by >> 8) == 3) ||
          ((info.m_version_made_by >> 8) ==
-          19)) // if zip is produced on Unix or macOS (3 and 19 from
-               // section 4.4.2.2 of zip standard)
+          19)) /*  if zip is produced on Unix or macOS (3 and 19 from
+                *  section 4.4.2.2 of zip standard) */
         && info.m_external_attr &
-               (0x20 << 24)) { // and has sym link attribute (0x80 is file, 0x40
-                               // is directory)
+               (0x20 << 24)) { /*  and has sym link attribute (0x80 is file, 0x40
+                                *  is directory) */
 #if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
     defined(__MINGW32__)
 #else
@@ -379,14 +384,14 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
     } else {
       if (!mz_zip_reader_is_file_a_directory(zip_archive, i)) {
         if (!mz_zip_reader_extract_to_file(zip_archive, i, path, 0)) {
-          // Cannot extract zip archive to file
+          /*  Cannot extract zip archive to file */
           err = ZIP_ENOFILE;
           goto out;
         }
       }
 
 #if defined(_MSC_VER) || defined(PS4)
-      (void)xattr; // unused
+      (void)xattr; /*  unused */
 #else
       xattr = (info.m_external_attr >> 16) & 0xFFFF;
       if (xattr > 0 && xattr <= MZ_UINT16_MAX) {
@@ -406,15 +411,21 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
   }
 
 out:
-  // Close the archive, freeing any resources it was using
+  /*  Close the archive, freeing any resources it was using */
   if (!mz_zip_reader_end(zip_archive)) {
-    // Cannot end zip reader
+    /*  Cannot end zip reader */
     err = ZIP_ECLSZIP;
   }
   return err;
 }
 
-static inline void zip_archive_finalize(mz_zip_archive *pzip) {
+static
+#if _MSC_VER > 1200
+inline
+#else
+__inline
+#endif
+void zip_archive_finalize(mz_zip_archive *pzip) {
   mz_zip_writer_finalize_archive(pzip);
   zip_archive_truncate(pzip);
 }
@@ -425,18 +436,20 @@ static ssize_t zip_entry_mark(struct zip_t *zip,
                               const size_t len) {
   ssize_t i = 0;
   ssize_t err = 0;
+  mz_zip_archive_file_stat file_stat;
+  mz_uint64 d_pos = ~0UL;
+
   if (!zip || !entry_mark || !entries) {
     return ZIP_ENOINIT;
   }
 
-  mz_zip_archive_file_stat file_stat;
-  mz_uint64 d_pos = ~0UL;
   for (i = 0; i < n; ++i) {
+    mz_bool name_matches = MZ_FALSE;
+
     if ((err = zip_entry_openbyindex(zip, i))) {
       return (ssize_t)err;
     }
 
-    mz_bool name_matches = MZ_FALSE;
     {
       size_t j;
       for (j = 0; j < len; ++j) {
@@ -520,13 +533,16 @@ static int zip_entry_finalize(struct zip_t *zip,
 
   ssize_t i = 0;
   mz_uint64 *local_header_ofs_array = (mz_uint64 *)calloc(n, sizeof(mz_uint64));
+  size_t *length;
+
   if (!local_header_ofs_array) {
     return ZIP_EOOMEM;
   }
 
   for (i = 0; i < n; ++i) {
+    ssize_t index;
     local_header_ofs_array[i] = entry_mark[i].m_local_header_ofs;
-    ssize_t index = zip_sort(local_header_ofs_array, i);
+    index = zip_sort(local_header_ofs_array, i);
 
     if (index != i) {
       zip_index_update(entry_mark, i, index);
@@ -534,7 +550,7 @@ static int zip_entry_finalize(struct zip_t *zip,
     entry_mark[i].file_index = index;
   }
 
-  size_t *length = (size_t *)calloc(n, sizeof(size_t));
+  length = (size_t *)calloc(n, sizeof(size_t));
   if (!length) {
     CLEANUP(local_header_ofs_array);
     return ZIP_EOOMEM;
@@ -598,14 +614,15 @@ static ssize_t zip_file_move(MZ_FILE *m_pFile, const mz_uint64 to,
 static ssize_t zip_files_move(MZ_FILE *m_pFile, mz_uint64 writen_num,
                               mz_uint64 read_num, size_t length) {
   ssize_t n = 0;
-  const size_t page_size = 1 << 12; // 4K
+  const size_t page_size = 1 << 12; /*  4K */
   mz_uint8 *move_buf = (mz_uint8 *)calloc(1, page_size);
+  ssize_t moved_length = 0;
+  ssize_t move_count = 0;
+
   if (!move_buf) {
     return ZIP_EOOMEM;
   }
 
-  ssize_t moved_length = 0;
-  ssize_t move_count = 0;
   while ((mz_int64)length > 0) {
     move_count = (length >= page_size) ? page_size : length;
     n = zip_file_move(m_pFile, writen_num, read_num, move_count, move_buf,
@@ -632,15 +649,17 @@ cleanup:
 
 static int zip_central_dir_move(mz_zip_internal_state *pState, int begin,
                                 int end, int entry_num) {
-  if (begin == entry_num) {
-    return 0;
-  }
-
   size_t l_size = 0;
   size_t r_size = 0;
   mz_uint32 d_size = 0;
   mz_uint8 *next = NULL;
-  mz_uint8 *deleted = &MZ_ZIP_ARRAY_ELEMENT(
+  mz_uint8 *deleted;
+
+  if (begin == entry_num) {
+    return 0;
+  }
+
+  deleted = &MZ_ZIP_ARRAY_ELEMENT(
       &pState->m_central_dir, mz_uint8,
       MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32, begin));
   l_size = (size_t)(deleted - (mz_uint8 *)(pState->m_central_dir.m_p));
@@ -704,6 +723,7 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
 
   i = 0;
   while (i < entry_num) {
+    int k = 0, j;
     while ((!deleted_entry_index_array[i]) && (i < entry_num)) {
       i++;
     }
@@ -715,7 +735,6 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
       i++;
     }
     end = i;
-    int k = 0, j;
     for (j = end; j < entry_num; j++) {
       MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32,
                            begin + k) =
@@ -741,6 +760,7 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
   int i = 0;
   size_t deleted_entry_num = 0;
   ssize_t n = 0;
+  mz_zip_internal_state *pState;
 
   mz_bool *deleted_entry_flag_array =
       (mz_bool *)calloc(entry_num, sizeof(mz_bool));
@@ -748,7 +768,7 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
     return ZIP_EOOMEM;
   }
 
-  mz_zip_internal_state *pState = zip->archive.m_pState;
+  pState = zip->archive.m_pState;
   zip->archive.m_zip_mode = MZ_ZIP_MODE_WRITING;
 
   if ((!pState->m_pFile) || MZ_FSEEK64(pState->m_pFile, 0, SEEK_SET)) {
@@ -772,15 +792,17 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
     }
 
     while ((entry_mark[i].type == MZ_MOVE) && (i < entry_num)) {
+      mz_uint8 *p;
+      mz_uint32 offset;
       move_length += entry_mark[i].lf_length;
-      mz_uint8 *p = &MZ_ZIP_ARRAY_ELEMENT(
+      p = &MZ_ZIP_ARRAY_ELEMENT(
           &pState->m_central_dir, mz_uint8,
           MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32, i));
       if (!p) {
         CLEANUP(deleted_entry_flag_array);
         return ZIP_ENOENT;
       }
-      mz_uint32 offset = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
+      offset = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
       offset -= (mz_uint32)deleted_length;
       MZ_WRITE_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS, offset);
       i++;
@@ -809,14 +831,14 @@ struct zip_t *zip_open(const char *zipname, int level, char mode) {
   struct zip_t *zip = NULL;
 
   if (!zipname || strlen(zipname) < 1) {
-    // zip_t archive name is empty or NULL
+    /*  zip_t archive name is empty or NULL */
     goto cleanup;
   }
 
   if (level < 0)
     level = MZ_DEFAULT_LEVEL;
   if ((level & 0xF) > MZ_UBER_COMPRESSION) {
-    // Wrong compression level
+    /*  Wrong compression level */
     goto cleanup;
   }
 
@@ -827,10 +849,10 @@ struct zip_t *zip_open(const char *zipname, int level, char mode) {
   zip->level = (mz_uint)level;
   switch (mode) {
   case 'w':
-    // Create a new archive.
+    /*  Create a new archive. */
     if (!mz_zip_writer_init_file_v2(&(zip->archive), zipname, 0,
                                     MZ_ZIP_FLAG_WRITE_ZIP64)) {
-      // Cannot initialize zip_archive writer
+      /*  Cannot initialize zip_archive writer */
       goto cleanup;
     }
     break;
@@ -841,8 +863,8 @@ struct zip_t *zip_open(const char *zipname, int level, char mode) {
     if (!mz_zip_reader_init_file_v2_rpb(
             &(zip->archive), zipname,
             zip->level | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY, 0, 0)) {
-      // An archive file does not exist or cannot initialize
-      // zip_archive reader
+      /*  An archive file does not exist or cannot initialize
+       *  zip_archive reader */
       goto cleanup;
     }
     if ((mode == 'a' || mode == 'd')) {
@@ -867,8 +889,8 @@ cleanup:
 
 void zip_close(struct zip_t *zip) {
   if (zip) {
-    // Always finalize, even if adding failed for some reason, so we have a
-    // valid central directory.
+    /*  Always finalize, even if adding failed for some reason, so we have a
+     *  valid central directory. */
     mz_zip_writer_finalize_archive(&(zip->archive));
     zip_archive_truncate(&(zip->archive));
     mz_zip_writer_end(&(zip->archive));
@@ -880,7 +902,7 @@ void zip_close(struct zip_t *zip) {
 
 int zip_is64(struct zip_t *zip) {
   if (!zip || !zip->archive.m_pState) {
-    // zip_t handler or zip state is not initialized
+    /*  zip_t handler or zip state is not initialized */
     return ZIP_ENOINIT;
   }
 
@@ -935,7 +957,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
 #endif
 
   if (!zip->entry.name) {
-    // Cannot parse zip entry name
+    /*  Cannot parse zip entry name */
     return ZIP_EINVENTNAME;
   }
 
@@ -979,9 +1001,9 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
   memset(zip->entry.header, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE * sizeof(mz_uint8));
   zip->entry.method = level ? MZ_DEFLATED : 0;
 
-  // UNIX or APPLE
+  /*  UNIX or APPLE */
 #if MZ_PLATFORM == 3 || MZ_PLATFORM == 19
-  // regular file with rw-r--r-- permissions
+  /*  regular file with rw-r--r-- permissions */
   zip->entry.external_attr = (mz_uint32)(0100644) << 16;
 #else
   zip->entry.external_attr = 0;
@@ -991,19 +1013,19 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
       mz_zip_writer_compute_padding_needed_for_file_alignment(pzip);
 
   if (!pzip->m_pState || (pzip->m_zip_mode != MZ_ZIP_MODE_WRITING)) {
-    // Invalid zip mode
+    /*  Invalid zip mode */
     err = ZIP_EINVMODE;
     goto cleanup;
   }
   if (zip->level & MZ_ZIP_FLAG_COMPRESSED_DATA) {
-    // Invalid zip compression level
+    /*  Invalid zip compression level */
     err = ZIP_EINVLVL;
     goto cleanup;
   }
 
   if (!mz_zip_writer_write_zeros(pzip, zip->entry.offset,
                                  num_alignment_padding_bytes)) {
-    // Cannot memset zip entry header
+    /*  Cannot memset zip entry header */
     err = ZIP_EMEMSET;
     goto cleanup;
   }
@@ -1014,8 +1036,8 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
   mz_zip_time_t_to_dos_time(zip->entry.m_time, &dos_time, &dos_date);
 #endif
 
-  // ZIP64 header with NULL sizes (sizes will be in the data descriptor, just
-  // after file data)
+  /*  ZIP64 header with NULL sizes (sizes will be in the data descriptor, just
+   *  after file data) */
   extra_size = mz_zip_writer_create_zip64_extra_data(
       extra_data, NULL, NULL,
       (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
@@ -1026,7 +1048,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
           MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8 |
               MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR,
           dos_time, dos_date)) {
-    // Cannot create zip entry header
+    /*  Cannot create zip entry header */
     err = ZIP_EMEMSET;
     goto cleanup;
   }
@@ -1036,7 +1058,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
   if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.header_offset,
                      zip->entry.header,
                      sizeof(zip->entry.header)) != sizeof(zip->entry.header)) {
-    // Cannot write zip entry header
+    /*  Cannot write zip entry header */
     err = ZIP_EMEMSET;
     goto cleanup;
   }
@@ -1049,7 +1071,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
 
   if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, zip->entry.name,
                      entrylen) != entrylen) {
-    // Cannot write data to zip entry
+    /*  Cannot write data to zip entry */
     err = ZIP_EWRTENT;
     goto cleanup;
   }
@@ -1058,7 +1080,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
 
   if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, extra_data,
                      extra_size) != extra_size) {
-    // Cannot write ZIP64 data to zip entry
+    /*  Cannot write ZIP64 data to zip entry */
     err = ZIP_EWRTENT;
     goto cleanup;
   }
@@ -1074,7 +1096,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
                    (int)tdefl_create_comp_flags_from_zip_params(
                        (int)level, -15, MZ_DEFAULT_STRATEGY)) !=
         TDEFL_STATUS_OKAY) {
-      // Cannot initialize the zip compressor
+      /*  Cannot initialize the zip compressor */
       err = ZIP_ETDEFLINIT;
       goto cleanup;
     }
@@ -1103,18 +1125,18 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
   const char *pFilename;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
   pZip = &(zip->archive);
   if (pZip->m_zip_mode != MZ_ZIP_MODE_READING) {
-    // open by index requires readonly mode
+    /*  open by index requires readonly mode */
     return ZIP_EINVMODE;
   }
 
   if (index >= (size_t)pZip->m_total_files) {
-    // index out of range
+    /*  index out of range */
     return ZIP_EINVIDX;
   }
 
@@ -1122,7 +1144,7 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
             &pZip->m_pState->m_central_dir, mz_uint8,
             MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets,
                                  mz_uint32, index)))) {
-    // cannot find header in central directory
+    /*  cannot find header in central directory */
     return ZIP_ENOHDR;
   }
 
@@ -1150,7 +1172,7 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
 #endif
 
   if (!zip->entry.name) {
-    // local entry name is NULL
+    /*  local entry name is NULL */
     return ZIP_EINVENTNAME;
   }
 
@@ -1187,7 +1209,7 @@ int zip_entry_close(struct zip_t *zip) {
   mz_uint32 local_dir_footer_size = MZ_ZIP_DATA_DESCRIPTER_SIZE64;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     err = ZIP_ENOINIT;
     goto cleanup;
   }
@@ -1201,7 +1223,7 @@ int zip_entry_close(struct zip_t *zip) {
   if (level) {
     done = tdefl_compress_buffer(&(zip->entry.comp), "", 0, TDEFL_FINISH);
     if (done != TDEFL_STATUS_DONE && done != TDEFL_STATUS_OKAY) {
-      // Cannot flush compressed buffer
+      /*  Cannot flush compressed buffer */
       err = ZIP_ETDEFLBUF;
       goto cleanup;
     }
@@ -1222,7 +1244,7 @@ int zip_entry_close(struct zip_t *zip) {
 
   if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, local_dir_footer,
                      local_dir_footer_size) != local_dir_footer_size) {
-    // Cannot write zip entry header
+    /*  Cannot write zip entry header */
     err = ZIP_EWRTHDR;
     goto cleanup;
   }
@@ -1251,7 +1273,7 @@ int zip_entry_close(struct zip_t *zip) {
               MZ_ZIP_LDH_BIT_FLAG_HAS_LOCATOR,
           dos_time, dos_date, zip->entry.header_offset,
           zip->entry.external_attr, NULL, 0)) {
-    // Cannot write to zip central dir
+    /*  Cannot write to zip central dir */
     err = ZIP_EWRTDIR;
     goto cleanup;
   }
@@ -1269,7 +1291,7 @@ cleanup:
 
 const char *zip_entry_name(struct zip_t *zip) {
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return NULL;
   }
 
@@ -1278,7 +1300,7 @@ const char *zip_entry_name(struct zip_t *zip) {
 
 ssize_t zip_entry_index(struct zip_t *zip) {
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return (ssize_t)ZIP_ENOINIT;
   }
 
@@ -1287,12 +1309,12 @@ ssize_t zip_entry_index(struct zip_t *zip) {
 
 int zip_entry_isdir(struct zip_t *zip) {
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
   if (zip->entry.index < (ssize_t)0) {
-    // zip entry is not opened
+    /*  zip entry is not opened */
     return ZIP_EINVIDX;
   }
 
@@ -1300,15 +1322,15 @@ int zip_entry_isdir(struct zip_t *zip) {
                                                 (mz_uint)zip->entry.index);
 }
 
-unsigned long long zip_entry_size(struct zip_t *zip) {
+zip_ull zip_entry_size(struct zip_t *zip) {
   return zip_entry_uncomp_size(zip);
 }
 
-unsigned long long zip_entry_uncomp_size(struct zip_t *zip) {
+zip_ull zip_entry_uncomp_size(struct zip_t *zip) {
   return zip ? zip->entry.uncomp_size : 0;
 }
 
-unsigned long long zip_entry_comp_size(struct zip_t *zip) {
+zip_ull zip_entry_comp_size(struct zip_t *zip) {
   return zip ? zip->entry.comp_size : 0;
 }
 
@@ -1322,7 +1344,7 @@ int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize) {
   tdefl_status status;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
@@ -1336,7 +1358,7 @@ int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize) {
     if (!level) {
       if ((pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, buf,
                           bufsize) != bufsize)) {
-        // Cannot write buffer
+        /*  Cannot write buffer */
         return ZIP_EWRTENT;
       }
       zip->entry.offset += bufsize;
@@ -1345,7 +1367,7 @@ int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize) {
       status = tdefl_compress_buffer(&(zip->entry.comp), buf, bufsize,
                                      TDEFL_NO_FLUSH);
       if (status != TDEFL_STATUS_DONE && status != TDEFL_STATUS_OKAY) {
-        // Cannot compress buffer
+        /*  Cannot compress buffer */
         return ZIP_ETDEFLBUF;
       }
     }
@@ -1363,19 +1385,19 @@ int zip_entry_fwrite(struct zip_t *zip, const char *filename) {
   mz_uint16 modes;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
   memset(buf, 0, MZ_ZIP_MAX_IO_BUF_SIZE);
   memset((void *)&file_stat, 0, sizeof(struct MZ_FILE_STAT_STRUCT));
   if (MZ_FILE_STAT(filename, &file_stat) != 0) {
-    // problem getting information - check errno
+    /*  problem getting information - check errno */
     return ZIP_ENOENT;
   }
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(DJGPP)
-  (void)modes; // unused
+  (void)modes; /*  unused */
 #else
   /* Initialize with permission bits--which are not implementation-optional */
   modes = file_stat.st_mode &
@@ -1403,7 +1425,7 @@ int zip_entry_fwrite(struct zip_t *zip, const char *filename) {
   zip->entry.m_time = file_stat.st_mtime;
 
   if (!(stream = MZ_FOPEN(filename, "rb"))) {
-    // Cannot open filename
+    /*  Cannot open filename */
     return ZIP_EOPNFILE;
   }
 
@@ -1425,20 +1447,20 @@ ssize_t zip_entry_read(struct zip_t *zip, void **buf, size_t *bufsize) {
   size_t size = 0;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return (ssize_t)ZIP_ENOINIT;
   }
 
   pzip = &(zip->archive);
   if (pzip->m_zip_mode != MZ_ZIP_MODE_READING ||
       zip->entry.index < (ssize_t)0) {
-    // the entry is not found or we do not have read access
+    /*  the entry is not found or we do not have read access */
     return (ssize_t)ZIP_ENOENT;
   }
 
   idx = (mz_uint)zip->entry.index;
   if (mz_zip_reader_is_file_a_directory(pzip, idx)) {
-    // the entry is a directory
+    /*  the entry is a directory */
     return (ssize_t)ZIP_EINVENTTYPE;
   }
 
@@ -1453,14 +1475,14 @@ ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf, size_t bufsize) {
   mz_zip_archive *pzip = NULL;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return (ssize_t)ZIP_ENOINIT;
   }
 
   pzip = &(zip->archive);
   if (pzip->m_zip_mode != MZ_ZIP_MODE_READING ||
       zip->entry.index < (ssize_t)0) {
-    // the entry is not found or we do not have read access
+    /*  the entry is not found or we do not have read access */
     return (ssize_t)ZIP_ENOENT;
   }
 
@@ -1479,7 +1501,7 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
   mz_zip_archive_file_stat info;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
@@ -1487,13 +1509,13 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
   pzip = &(zip->archive);
   if (pzip->m_zip_mode != MZ_ZIP_MODE_READING ||
       zip->entry.index < (ssize_t)0) {
-    // the entry is not found or we do not have read access
+    /*  the entry is not found or we do not have read access */
     return ZIP_ENOENT;
   }
 
   idx = (mz_uint)zip->entry.index;
   if (mz_zip_reader_is_file_a_directory(pzip, idx)) {
-    // the entry is a directory
+    /*  the entry is a directory */
     return ZIP_EINVENTTYPE;
   }
 
@@ -1502,10 +1524,10 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
   }
 
 #if defined(_MSC_VER) || defined(PS4)
-  (void)xattr; // unused
+  (void)xattr; /*  unused */
 #else
   if (!mz_zip_reader_file_stat(pzip, idx, &info)) {
-    // Cannot get information about zip archive;
+    /*  Cannot get information about zip archive; */
     return ZIP_ENOFILE;
   }
 
@@ -1528,14 +1550,14 @@ int zip_entry_extract(struct zip_t *zip,
   mz_uint idx;
 
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
   pzip = &(zip->archive);
   if (pzip->m_zip_mode != MZ_ZIP_MODE_READING ||
       zip->entry.index < (ssize_t)0) {
-    // the entry is not found or we do not have read access
+    /*  the entry is not found or we do not have read access */
     return ZIP_ENOENT;
   }
 
@@ -1547,7 +1569,7 @@ int zip_entry_extract(struct zip_t *zip,
 
 ssize_t zip_entries_total(struct zip_t *zip) {
   if (!zip) {
-    // zip_t handler is not initialized
+    /*  zip_t handler is not initialized */
     return ZIP_ENOINIT;
   }
 
@@ -1594,15 +1616,15 @@ int zip_stream_extract(const char *stream, size_t size, const char *dir,
                        void *arg) {
   mz_zip_archive zip_archive;
   if (!stream || !dir) {
-    // Cannot parse zip archive stream
+    /*  Cannot parse zip archive stream */
     return ZIP_ENOINIT;
   }
   if (!memset(&zip_archive, 0, sizeof(mz_zip_archive))) {
-    // Cannot memset zip archive
+    /*  Cannot memset zip archive */
     return ZIP_EMEMSET;
   }
   if (!mz_zip_reader_init_mem(&zip_archive, stream, size, 0)) {
-    // Cannot initialize zip_archive reader
+    /*  Cannot initialize zip_archive reader */
     return ZIP_ENOINIT;
   }
 
@@ -1620,7 +1642,7 @@ struct zip_t *zip_stream_open(const char *stream, size_t size, int level,
     level = MZ_DEFAULT_LEVEL;
   }
   if ((level & 0xF) > MZ_UBER_COMPRESSION) {
-    // Wrong compression level
+    /*  Wrong compression level */
     goto cleanup;
   }
   zip->level = (mz_uint)level;
@@ -1630,9 +1652,9 @@ struct zip_t *zip_stream_open(const char *stream, size_t size, int level,
       goto cleanup;
     }
   } else if ((stream == NULL) && (size == 0) && (mode == 'w')) {
-    // Create a new archive.
+    /*  Create a new archive. */
     if (!mz_zip_writer_init_heap(&(zip->archive), 0, 1024)) {
-      // Cannot initialize zip_archive writer
+      /*  Cannot initialize zip_archive writer */
       goto cleanup;
     }
   } else {
@@ -1681,18 +1703,18 @@ int zip_create(const char *zipname, const char *filenames[], size_t len) {
   mz_uint16 modes;
 
   if (!zipname || strlen(zipname) < 1) {
-    // zip_t archive name is empty or NULL
+    /*  zip_t archive name is empty or NULL */
     return ZIP_EINVZIPNAME;
   }
 
-  // Create a new archive.
+  /*  Create a new archive. */
   if (!memset(&(zip_archive), 0, sizeof(zip_archive))) {
-    // Cannot memset zip archive
+    /*  Cannot memset zip archive */
     return ZIP_EMEMSET;
   }
 
   if (!mz_zip_writer_init_file(&zip_archive, zipname, 0)) {
-    // Cannot initialize zip_archive writer
+    /*  Cannot initialize zip_archive writer */
     return ZIP_ENOINIT;
   }
 
@@ -1708,13 +1730,13 @@ int zip_create(const char *zipname, const char *filenames[], size_t len) {
     }
 
     if (MZ_FILE_STAT(name, &file_stat) != 0) {
-      // problem getting information - check errno
+      /*  problem getting information - check errno */
       err = ZIP_ENOFILE;
       break;
     }
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(DJGPP)
-    (void)modes; // unused
+    (void)modes; /*  unused */
 #else
 
     /* Initialize with permission bits--which are not implementation-optional */
@@ -1743,7 +1765,7 @@ int zip_create(const char *zipname, const char *filenames[], size_t len) {
     if (!mz_zip_writer_add_file(&zip_archive, zip_basename(name), name, "", 0,
                                 ZIP_DEFAULT_COMPRESSION_LEVEL,
                                 ext_attributes)) {
-      // Cannot add file to zip_archive
+      /*  Cannot add file to zip_archive */
       err = ZIP_ENOFILE;
       break;
     }
@@ -1759,18 +1781,18 @@ int zip_extract(const char *zipname, const char *dir,
   mz_zip_archive zip_archive;
 
   if (!zipname || !dir) {
-    // Cannot parse zip archive name
+    /*  Cannot parse zip archive name */
     return ZIP_EINVZIPNAME;
   }
 
   if (!memset(&zip_archive, 0, sizeof(mz_zip_archive))) {
-    // Cannot memset zip archive
+    /*  Cannot memset zip archive */
     return ZIP_EMEMSET;
   }
 
-  // Now try to open the archive.
+  /*  Now try to open the archive. */
   if (!mz_zip_reader_init_file(&zip_archive, zipname, 0)) {
-    // Cannot initialize zip_archive reader
+    /*  Cannot initialize zip_archive reader */
     return ZIP_ENOINIT;
   }
 

--- a/src/zip.c
+++ b/src/zip.c
@@ -364,8 +364,8 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
           19)) /*  if zip is produced on Unix or macOS (3 and 19 from
                 *  section 4.4.2.2 of zip standard) */
         && info.m_external_attr &
-               (0x20 << 24)) { /*  and has sym link attribute (0x80 is file, 0x40
-                                *  is directory) */
+               (0x20 << 24)) { /*  and has sym link attribute (0x80 is file,
+                                * 0x40 is directory) */
 #if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
     defined(__MINGW32__)
 #else
@@ -421,11 +421,12 @@ out:
 
 static
 #if _MSC_VER > 1200
-inline
+    inline
 #else
-__inline
+    __inline
 #endif
-void zip_archive_finalize(mz_zip_archive *pzip) {
+    void
+    zip_archive_finalize(mz_zip_archive *pzip) {
   mz_zip_writer_finalize_archive(pzip);
   zip_archive_truncate(pzip);
 }
@@ -1322,9 +1323,7 @@ int zip_entry_isdir(struct zip_t *zip) {
                                                 (mz_uint)zip->entry.index);
 }
 
-zip_ull zip_entry_size(struct zip_t *zip) {
-  return zip_entry_uncomp_size(zip);
-}
+zip_ull zip_entry_size(struct zip_t *zip) { return zip_entry_uncomp_size(zip); }
 
 zip_ull zip_entry_uncomp_size(struct zip_t *zip) {
   return zip ? zip->entry.uncomp_size : 0;

--- a/src/zip.h
+++ b/src/zip.h
@@ -12,7 +12,26 @@
 #ifndef ZIP_H
 #define ZIP_H
 
+#if _MSC_VER == 1200
+// no stdint with MSVC 6.0, so work around it
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+
+typedef uint64_t zip_ull;
+
+#else
 #include <stdint.h>
+
+typedef unsigned long long zip_ull;
+
+#endif
+
 #include <string.h>
 #include <sys/types.h>
 
@@ -35,8 +54,8 @@ extern "C" {
 #endif
 
 #if !defined(_POSIX_C_SOURCE) && defined(_MSC_VER)
-// 64-bit Windows is the only mainstream platform
-// where sizeof(long) != sizeof(void*)
+/*  64-bit Windows is the only mainstream platform
+ *  where sizeof(long) != sizeof(void*) */
 #ifdef _WIN64
 typedef long long ssize_t; /* byte count or error */
 #else
@@ -67,35 +86,35 @@ typedef long ssize_t; /* byte count or error */
 /**
  * Error codes
  */
-#define ZIP_ENOINIT -1      // not initialized
-#define ZIP_EINVENTNAME -2  // invalid entry name
-#define ZIP_ENOENT -3       // entry not found
-#define ZIP_EINVMODE -4     // invalid zip mode
-#define ZIP_EINVLVL -5      // invalid compression level
-#define ZIP_ENOSUP64 -6     // no zip 64 support
-#define ZIP_EMEMSET -7      // memset error
-#define ZIP_EWRTENT -8      // cannot write data to entry
-#define ZIP_ETDEFLINIT -9   // cannot initialize tdefl compressor
-#define ZIP_EINVIDX -10     // invalid index
-#define ZIP_ENOHDR -11      // header not found
-#define ZIP_ETDEFLBUF -12   // cannot flush tdefl buffer
-#define ZIP_ECRTHDR -13     // cannot create entry header
-#define ZIP_EWRTHDR -14     // cannot write entry header
-#define ZIP_EWRTDIR -15     // cannot write to central dir
-#define ZIP_EOPNFILE -16    // cannot open file
-#define ZIP_EINVENTTYPE -17 // invalid entry type
-#define ZIP_EMEMNOALLOC -18 // extracting data using no memory allocation
-#define ZIP_ENOFILE -19     // file not found
-#define ZIP_ENOPERM -20     // no permission
-#define ZIP_EOOMEM -21      // out of memory
-#define ZIP_EINVZIPNAME -22 // invalid zip archive name
-#define ZIP_EMKDIR -23      // make dir error
-#define ZIP_ESYMLINK -24    // symlink error
-#define ZIP_ECLSZIP -25     // close archive error
-#define ZIP_ECAPSIZE -26    // capacity size too small
-#define ZIP_EFSEEK -27      // fseek error
-#define ZIP_EFREAD -28      // fread error
-#define ZIP_EFWRITE -29     // fwrite error
+#define ZIP_ENOINIT -1      /*  not initialized */
+#define ZIP_EINVENTNAME -2  /*  invalid entry name */
+#define ZIP_ENOENT -3       /*  entry not found */
+#define ZIP_EINVMODE -4     /*  invalid zip mode */
+#define ZIP_EINVLVL -5      /*  invalid compression level */
+#define ZIP_ENOSUP64 -6     /*  no zip 64 support */
+#define ZIP_EMEMSET -7      /*  memset error */
+#define ZIP_EWRTENT -8      /*  cannot write data to entry */
+#define ZIP_ETDEFLINIT -9   /*  cannot initialize tdefl compressor */
+#define ZIP_EINVIDX -10     /*  invalid index */
+#define ZIP_ENOHDR -11      /*  header not found */
+#define ZIP_ETDEFLBUF -12   /*  cannot flush tdefl buffer */
+#define ZIP_ECRTHDR -13     /*  cannot create entry header */
+#define ZIP_EWRTHDR -14     /*  cannot write entry header */
+#define ZIP_EWRTDIR -15     /*  cannot write to central dir */
+#define ZIP_EOPNFILE -16    /*  cannot open file */
+#define ZIP_EINVENTTYPE -17 /*  invalid entry type */
+#define ZIP_EMEMNOALLOC -18 /*  extracting data using no memory allocation */
+#define ZIP_ENOFILE -19     /*  file not found */
+#define ZIP_ENOPERM -20     /*  no permission */
+#define ZIP_EOOMEM -21      /*  out of memory */
+#define ZIP_EINVZIPNAME -22 /*  invalid zip archive name */
+#define ZIP_EMKDIR -23      /*  make dir error */
+#define ZIP_ESYMLINK -24    /*  symlink error */
+#define ZIP_ECLSZIP -25     /*  close archive error */
+#define ZIP_ECAPSIZE -26    /*  capacity size too small */
+#define ZIP_EFSEEK -27      /*  fseek error */
+#define ZIP_EFREAD -28      /*  fread error */
+#define ZIP_EFWRITE -29     /*  fwrite error */
 
 /**
  * Looks up the error message string coresponding to an error number.
@@ -238,7 +257,7 @@ extern ZIP_EXPORT int zip_entry_isdir(struct zip_t *zip);
  *
  * @return the uncompressed size in bytes.
  */
-extern ZIP_EXPORT unsigned long long zip_entry_size(struct zip_t *zip);
+extern ZIP_EXPORT zip_ull zip_entry_size(struct zip_t *zip);
 
 /**
  * Returns the uncompressed size of the current zip entry.
@@ -247,7 +266,7 @@ extern ZIP_EXPORT unsigned long long zip_entry_size(struct zip_t *zip);
  *
  * @return the uncompressed size in bytes.
  */
-extern ZIP_EXPORT unsigned long long zip_entry_uncomp_size(struct zip_t *zip);
+extern ZIP_EXPORT zip_ull zip_entry_uncomp_size(struct zip_t *zip);
 
 /**
  * Returns the compressed size of the current zip entry.
@@ -256,7 +275,7 @@ extern ZIP_EXPORT unsigned long long zip_entry_uncomp_size(struct zip_t *zip);
  *
  * @return the compressed size in bytes.
  */
-extern ZIP_EXPORT unsigned long long zip_entry_comp_size(struct zip_t *zip);
+extern ZIP_EXPORT zip_ull zip_entry_comp_size(struct zip_t *zip);
 
 /**
  * Returns CRC-32 checksum of the current zip entry.


### PR DESCRIPTION
- Change comments to be ANSI C style
- Use MSVC-specific __int* types instead of stdint
- Replace unsigned long long type with a unsigned __int64 (introducing a zip_ull typedef)
- Remove calls to MS-specific functions that did not exist in MSVC 6.0:
  - _wfopen_s -> _wfopen
  - _wfreopen_s -> _wfreopen
  - _wstat64 -> wstati64 (along with _stat64 struct)
  - _ftelli64 -> ftell
  - _fseeki64 -> fseek
  - localtime_s -> localtime
  - _chsize_s -> _chsize
  - strcpy_s -> strcpy
  - strncpy_s -> strncpy
- Use __inline attribute instead of inline
- Move variable definitions to the start of the blocks