### PR TITLE
Allow opening read-only ZIP files

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -842,6 +842,15 @@ struct zip_t *zip_open(const char *zipname, int level, char mode) {
     break;
 
   case 'r':
+    if (!mz_zip_reader_init_file_v2(
+            &(zip->archive), zipname,
+            zip->level | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY, 0, 0)) {
+      // An archive file does not exist or cannot initialize
+      // zip_archive reader
+      goto cleanup;
+    }
+    break;
+
   case 'a':
   case 'd':
     if (!mz_zip_reader_init_file_v2_rpb(


### PR DESCRIPTION
The function `zip_open("somefile.zip", 0, 'r');` fails if `somefile.zip` is read-only.

To test this, just add a call to `chmod(ZIPNAME, S_IRUSR);` (needs `sys/stat.h` included) to the end of `test_setup()` in `test/test_read.c`.

The reason for this is that `'r'` uses this:

https://github.com/kuba--/zip/blob/114d9d46fdbdad55b37705190a8625f4ab5fa81a/src/zip.c#L847

..which in turn uses this:

https://github.com/kuba--/zip/blob/114d9d46fdbdad55b37705190a8625f4ab5fa81a/src/miniz.h#L5999

An `fopen()` with mode `r+` means that it's opened read-write.

This PR fixes it by using `mz_zip_reader_init_file_v2()` (which opens in `rb` mode, not `r+b` mode) when opening files in `'r'` mode.

This fix should help with the downstream issue https://github.com/SuperIlu/DOjS/issues/28