### PR TITLE
Fix clang build error on Windows

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4016,7 +4016,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h,
  */
 /* non-C language bindings to tdefL_ and tinfl_ API don't need to worry about */
 /* structure size and allocation mechanism. */
-tdefl_compressor *tdefl_compressor_alloc() {
+tdefl_compressor *tdefl_compressor_alloc(void) {
   return (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor));
 }
 
@@ -4768,7 +4768,7 @@ int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size,
 }
 
 #ifndef MINIZ_NO_MALLOC
-tinfl_decompressor *tinfl_decompressor_alloc() {
+tinfl_decompressor *tinfl_decompressor_alloc(void) {
   tinfl_decompressor *pDecomp =
       (tinfl_decompressor *)MZ_MALLOC(sizeof(tinfl_decompressor));
   if (pDecomp)


### PR DESCRIPTION
This fixes clang yelling about `*tdefl_compressor_alloc()` and `tinfl_decompressor_alloc()`

```
zip/src/miniz.h:4019:41: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
zip/src/miniz.h:4771:45: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```