### PR TITLE
Fix zip_delete_entries bug

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -666,7 +666,6 @@ static int zip_central_dir_move(mz_zip_internal_state *pState, int begin,
 
   if (next && l_size == 0) {
     memmove(pState->m_central_dir.m_p, next, r_size);
-    pState->m_central_dir.m_p = MZ_REALLOC(pState->m_central_dir.m_p, r_size);
     {
       int i;
       for (i = end; i < entry_num; i++) {
@@ -735,8 +734,7 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
     d_num += end - begin;
   }
 
-  pState->m_central_dir_offsets.m_size =
-      sizeof(mz_uint32) * (entry_num - d_num);
+  pState->m_central_dir_offsets.m_size = entry_num - d_num;
   return 0;
 }
 


### PR DESCRIPTION
## Purpose
Fix bugs in zip_delete_entires which crashed the central directory states.
## Elaborate
I discover these bug when trying to use this API along with other entry writing APIs in same zip_open/zip_close section, for example:
```c
    struct zip_t* obj = zip_open("foo.zip", ZIP_DEFAULT_COMPRESSION_LEVEL, 'a');
    {
        const char* entname = "bar.txt";
        // Delete the old entries with same names
        zip_delete_entires(obj, &entname, 1);
        // Add the new entry
        zip_entry_open(obj, entname);
        zip_entry_write(obj, "foobar", sizeof("foobar"));
        zip_entry_close(obj);
    }
    zip_close(obj);
```  