### PR TITLE
for windows ZIP_ENABLE_SHARABLE_FILE_OPEN

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -4968,20 +4968,36 @@ static FILE *mz_fopen(const char *pFilename, const char *pMode) {
   WCHAR *wFilename = mz_utf8z_to_widechar(pFilename);
   WCHAR *wMode = mz_utf8z_to_widechar(pMode);
   FILE *pFile = NULL;
+#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+  pFile = _wfopen(wFilename, wMode);
+#else
   errno_t err = _wfopen_s(&pFile, wFilename, wMode);
+#endif
   free(wFilename);
   free(wMode);
+#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+  return pFile;
+#else
   return err ? NULL : pFile;
+#endif
 }
 
 static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream) {
   WCHAR *wPath = mz_utf8z_to_widechar(pPath);
   WCHAR *wMode = mz_utf8z_to_widechar(pMode);
   FILE *pFile = NULL;
+#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+  pFile = _wfreopen(wPath, wMode, pStream);
+#else
   errno_t err = _wfreopen_s(&pFile, wPath, wMode, pStream);
+#endif
   free(wPath);
   free(wMode);
+#ifdef ZIP_ENABLE_SHARABLE_FILE_OPEN
+  return pFile;
+#else
   return err ? NULL : pFile;
+#endif
 }
 
 static int mz_stat64(const char *path, struct __stat64 *buffer) {


### PR DESCRIPTION
I remember I created this pr 3 years ago, but recently I upgrade to 0.3.0 , and found on windows can not zip the opened files.
so I check the macro lost. just add them back.