### PR TITLE
Fix incorrect order of argument to calloc

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1874,7 +1874,7 @@ ssize_t zip_stream_copy(struct zip_t *zip, void **buf, size_t *bufsize) {
     *bufsize = n;
   }
 
-  *buf = calloc(sizeof(unsigned char), n);
+  *buf = calloc(n, sizeof(unsigned char));
   memcpy(*buf, zip->archive.m_pState->m_pMem, n);
 
   return (ssize_t)n;


### PR DESCRIPTION
Compiling the code with GCC14 this particular line triggers calloc-transposed-args since the size is provided as the first argument. The order of arguments for calloc is number and then size.