### PR TITLE
Fix permissions to work with unzip

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -8367,6 +8367,7 @@ static mz_bool mz_zip_writer_create_central_dir_header(
   (void)pZip;
   memset(pDst, 0, MZ_ZIP_CENTRAL_DIR_HEADER_SIZE);
   MZ_WRITE_LE32(pDst + MZ_ZIP_CDH_SIG_OFS, MZ_ZIP_CENTRAL_DIR_HEADER_SIG);
+  MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_MADE_BY_OFS, 0x031E);
   MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_VERSION_NEEDED_OFS, method ? 20 : 0);
   MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_BIT_FLAG_OFS, bit_flags);
   MZ_WRITE_LE16(pDst + MZ_ZIP_CDH_METHOD_OFS, method);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,19 @@ add_sanitizers(${test_entry_out})
 set(test_permissions_out test_permissions.out)
 add_executable(${test_permissions_out} test_permissions.c)
 target_link_libraries(${test_permissions_out} zip)
+if(LINUX OR UNIX)
+    find_program(UNZIP_PROGRAM unzip)
+    if(UNZIP_PROGRAM)
+        message(STATUS "Found unzip: ${UNZIP_PROGRAM}")
+        if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
+          "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
+          "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+            target_compile_definitions(${test_permissions_out}
+              PRIVATE UNZIP_PROGRAM="${UNZIP_PROGRAM}"
+            )
+        endif()
+    endif()
+endif()
 add_test(NAME ${test_permissions_out} COMMAND ${test_permissions_out})
 add_sanitizers(${test_permissions_out})
 

--- a/test/test_permissions.c
+++ b/test/test_permissions.c
@@ -66,6 +66,17 @@ MU_TEST(test_exe_permissions) {
 
   mu_assert_int_eq(0, MZ_FILE_STAT(XFILE, &file_stats));
   mu_assert_int_eq(XMODE, file_stats.st_mode);
+
+#ifdef UNZIP_PROGRAM
+  remove(XFILE);
+
+  char command[128];
+  sprintf(command, "%s %s", UNZIP_PROGRAM, ZIPNAME);
+  mu_assert_int_eq(0, system(command));
+
+  mu_assert_int_eq(0, MZ_FILE_STAT(XFILE, &file_stats));
+  mu_assert_int_eq(XMODE, file_stats.st_mode);
+#endif
 }
 
 MU_TEST(test_read_permissions) {


### PR DESCRIPTION
The version-made-by field was not set when creating an archive. When the archive is extracted by unzip in Linux and macOS, the origin file permissions (especially executable perms) are lost. 

This patch adds the missing field.