### PR TITLE
Added patches to zip.c to prevent OOM while fuzzing

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -5,12 +5,13 @@
 set(CMAKE_C_STANDARD 23)
 
 add_definitions(-DNDEBUG)  # Do not want assertions
+add_compile_definitions(OSS_FUZZ_BUILD=1)
 
 if (DEFINED ENV{CFLAGS})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} $ENV{CFLAGS}")
 endif ()
 
-add_executable(read_entry_fuzzer read_entry_fuzzer.c)
+add_executable(read_entry_fuzzer read_entry_fuzzer.c ../src/zip.c)
 target_link_libraries(read_entry_fuzzer PRIVATE ${PROJECT_NAME} $ENV{LIB_FUZZING_ENGINE})
 
 add_executable(create_zip_fuzzer create_zip_fuzzer.c)


### PR DESCRIPTION
Responding to https://github.com/kuba--/zip/pull/367#discussion_r1958774563

This PR adds a compiler definition specific to OSSFUZZ builds and bails prior to attempting to malloc beyond 1 gigabyte while fuzzing