### PR TITLE
Add function to check for symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ for (i = 0; i < n; ++i) {
     {
         const char *name = zip_entry_name(zip);
         int isdir = zip_entry_isdir(zip);
+        int issymlink = zip_entry_issymlink(zip);
         unsigned long long size = zip_entry_size(zip);
         unsigned int crc32 = zip_entry_crc32(zip);
     }

--- a/src/zip.c
+++ b/src/zip.c
@@ -223,6 +223,7 @@ struct zip_entry_t {
   mz_uint8 header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
   mz_uint64 header_offset;
   mz_uint16 method;
+  mz_uint16 version_made_by;
 #if ZIP_ENABLE_DEFLATE
   mz_zip_writer_add_state state;
   tdefl_compressor comp;
@@ -528,6 +529,17 @@ static int zip_archive_truncate(mz_zip_archive *pzip) {
 }
 #endif /* ZIP_ENABLE_DEFLATE */
 
+static mz_bool zip_stat_is_symlink(mz_uint16 version_made_by,
+                                   mz_uint32 external_attr) {
+  // if zip is produced on Unix or macOS (3 and 19 from
+  // section 4.4.2.2 of zip standard)
+  mz_bool is_unix_or_macos =
+      ((version_made_by >> 8) == 3) || ((version_made_by >> 8) == 19);
+
+  // and has sym link attribute (0x80 is file, 0x40 is directory)
+  return is_unix_or_macos && (external_attr & (0x20 << 24));
+}
+
 #if ZIP_ENABLE_INFLATE
 #ifndef MINIZ_NO_STDIO
 
@@ -603,13 +615,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
       goto out;
     }
 
-    if ((((info.m_version_made_by >> 8) == 3) ||
-         ((info.m_version_made_by >> 8) ==
-          19)) // if zip is produced on Unix or macOS (3 and 19 from
-               // section 4.4.2.2 of zip standard)
-        && info.m_external_attr &
-               (0x20 << 24)) { // and has sym link attribute (0x80 is file,
-                               // 0x40 is directory)
+    if (zip_stat_is_symlink(info.m_version_made_by, info.m_external_attr)) {
 #if ZIP_HAVE_SYMLINK
       if (info.m_uncomp_size > MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE ||
           !mz_zip_reader_extract_to_mem_no_alloc(
@@ -1510,6 +1516,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
     zip->entry.dir_offset = stats.m_central_dir_ofs;
     zip->entry.header_offset = stats.m_local_header_ofs;
     zip->entry.method = stats.m_method;
+    zip->entry.version_made_by = stats.m_version_made_by;
     zip->entry.external_attr = stats.m_external_attr;
 #ifndef MINIZ_NO_TIME
     zip->entry.m_time = stats.m_time;
@@ -1548,6 +1555,7 @@ static int _zip_entry_open(struct zip_t *zip, const char *entryname,
   zip->entry.header_offset = zip->archive.m_archive_size;
   memset(zip->entry.header, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE * sizeof(mz_uint8));
   zip->entry.method = level ? MZ_DEFLATED : 0;
+  zip->entry.version_made_by = 0;
 
   // UNIX or APPLE
 #if MZ_PLATFORM == 3 || MZ_PLATFORM == 19
@@ -1764,6 +1772,7 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
   zip->entry.dir_offset = stats.m_central_dir_ofs;
   zip->entry.header_offset = stats.m_local_header_ofs;
   zip->entry.method = stats.m_method;
+  zip->entry.version_made_by = stats.m_version_made_by;
   zip->entry.external_attr = stats.m_external_attr;
 #ifndef MINIZ_NO_TIME
   zip->entry.m_time = stats.m_time;
@@ -2032,6 +2041,21 @@ int zip_entry_isdir(struct zip_t *zip) {
     return 0;
   }
   return ISSLASH(zip->entry.name[entrylen - 1]);
+}
+
+int zip_entry_issymlink(struct zip_t *zip) {
+  if (!zip) {
+    // zip_t handler is not initialized
+    return ZIP_ENOINIT;
+  }
+
+  if (zip->entry.index < (ssize_t)0) {
+    // zip entry is not opened
+    return ZIP_EINVIDX;
+  }
+
+  return zip_stat_is_symlink(zip->entry.version_made_by,
+                             zip->entry.external_attr);
 }
 
 unsigned long long zip_entry_size(struct zip_t *zip) {

--- a/src/zip.h
+++ b/src/zip.h
@@ -322,6 +322,16 @@ extern ZIP_EXPORT ssize_t zip_entry_index(struct zip_t *zip);
 extern ZIP_EXPORT int zip_entry_isdir(struct zip_t *zip);
 
 /**
+ * Determines if the current zip entry is a symlink.
+ *
+ * @param zip zip archive handler.
+ *
+ * @return the return code - 1 (true), 0 (false), negative number (< 0) on
+ *         error.
+ */
+extern ZIP_EXPORT int zip_entry_issymlink(struct zip_t *zip);
+
+/**
  * Returns the uncompressed size of the current zip entry.
  * Alias for zip_entry_uncomp_size (for backward compatibility).
  *


### PR DESCRIPTION
Before extracting, I want to check if the zip file has any symlinks and reject these files. To do this, I added a helper `zip_entry_issymlink` to check if an entry is a symlink. This uses the same logic as `zip_archive_extract` did.