### PR TITLE
Fix `stringop-truncation` warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
             flags: -DZIP_ENABLE_INFLATE=OFF -DZIP_ENABLE_DEFLATE=OFF -DZIP_HAVE_SYMLINK=OFF
           - name: no-stdio
             flags: -DMINIZ_NO_STDIO=ON
+          - name: release
+            flags: -DCMAKE_BUILD_TYPE=Release
     name: compile-flags (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v2

--- a/src/zip.c
+++ b/src/zip.c
@@ -377,6 +377,7 @@ static int zip_mkpath(char *path, size_t pos) {
 
   memset(npath, 0, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE + 1);
   strncpy(npath, path, len);
+  npath[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE] = '\0';
 
   if (MZ_FILE_STAT(npath, &st) < 0) {
     return ZIP_ENOFILE;
@@ -542,7 +543,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
   char symlink_to[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE + 1];
 #endif
   mz_zip_archive_file_stat info;
-  size_t dirlen = 0, filename_size = MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE;
+  size_t dirlen = 0, filename_size;
   mz_uint32 xattr = 0;
 
   memset(path, 0, sizeof(path));
@@ -572,9 +573,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
     ++dirlen;
   }
 
-  if (filename_size > MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE - dirlen) {
-    filename_size = MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE - dirlen;
-  }
+  filename_size = sizeof(path) / sizeof(char) - dirlen;
   // Get and print information about each file in the archive.
   n = mz_zip_reader_get_num_files(zip_archive);
   for (i = 0; i < n; ++i) {
@@ -596,6 +595,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
 #else
     strncpy(&path[dirlen], info.m_filename, filename_size);
 #endif
+    path[sizeof(path) / sizeof(char) - 1] = '\0';
 
     err = zip_mkpath(path, dirlen);
     if (err < 0) {


### PR DESCRIPTION
GCC has `-Wstringop-truncation`, but this warning only shows up if optimizations are enabled. It showed up in two places:

1. In `zip_mkpath` at `strncpy`: If all `len` bytes are copied, the string isn't truncated, so always add a null terminator.
2. In `zip_archive_extract` at `strncpy`: The size available for the file path is `sizeof(path) - dirlen`; if `sizeof(path) - dirlen - 1` is used, GCC complains.

I added a release configuration in CI to hopefully catch this earlier.