### PR TITLE
clamp offset against decrypted size in zip_entry_noallocreadwithoffset

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2405,6 +2405,10 @@ ssize_t zip_entry_noallocreadwithoffset(struct zip_t *zip, size_t offset,
     if (n < 0) {
       return n;
     }
+    if (offset >= heap_size) {
+      free(heap_buf);
+      return (ssize_t)0;
+    }
     if (offset + size > heap_size) {
       size = heap_size - offset;
     }


### PR DESCRIPTION
Fuzzing the password read path crashed here. The top of the function clamps offset/size against the entry's declared uncomp_size, but for a stored entry whose declared size exceeds the real decrypted bytes (crafted archive), the password branch then computes size = heap_size - offset against the actual size. When offset lands past heap_size that underflows to ~SIZE_MAX and the memcpy runs far out of bounds. Bail out when offset is past the decrypted data.