### PR TITLE
Add const qualifier to name parameter in zip_name_normalize

### DIFF
--- a/test/test_static.c
+++ b/test/test_static.c
@@ -15,7 +15,7 @@ static inline int zip_strchr_match(const char *const str, size_t len, char c) {
   return 1;
 }
 
-static char *zip_name_normalize(char *name, char *const nname, size_t len) {
+static char *zip_name_normalize(const char *name, char *const nname, size_t len) {
   size_t offn = 0, ncpy = 0;
   char c;
 


### PR DESCRIPTION
## 问题背景
函数 `zip_name_normalize` 在 `test/test_static.c` 文件中，其 `name` 参数仅被读取，但未声明为 `const`，这违反了类型安全性的最佳实践，可能导致编译器警告或意外修改风险。

## 修改内容
将 `name` 参数的类型从 `char *` 改为 `const char *`，以明确表示该参数是只读输入。此改动提高了代码的清晰度和类型安全性，而不改变函数行为或公共 API。

## 验证方式
- 编译代码并运行现有测试套件，确保所有测试通过。
- 验证函数的输入输出行为与修改前一致，因为参数现在仅被读取。