### PR TITLE
strip setuid/setgid/sticky bits when restoring archived modes

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -65,6 +65,17 @@
 #define ISSLASH(C) ((C) == '/' || (C) == '\\')
 #endif
 
+/* setuid/setgid/sticky bits are not defined on every toolchain (e.g. MinGW) */
+#ifndef S_ISUID
+#define S_ISUID 04000
+#endif
+#ifndef S_ISGID
+#define S_ISGID 02000
+#endif
+#ifndef S_ISVTX
+#define S_ISVTX 01000
+#endif
+
 #define CLEANUP(ptr)                                                           \
   do {                                                                         \
     if (ptr) {                                                                 \

--- a/src/zip.c
+++ b/src/zip.c
@@ -65,16 +65,8 @@
 #define ISSLASH(C) ((C) == '/' || (C) == '\\')
 #endif
 
-/* setuid/setgid/sticky bits are not defined on every toolchain (e.g. MinGW) */
-#ifndef S_ISUID
-#define S_ISUID 04000
-#endif
-#ifndef S_ISGID
-#define S_ISGID 02000
-#endif
-#ifndef S_ISVTX
-#define S_ISVTX 01000
-#endif
+/* setuid/setgid/sticky bits (S_ISUID | S_ISGID | S_ISVTX) */
+#define ZIP_SETID_MASK 07000
 
 #define CLEANUP(ptr)                                                           \
   do {                                                                         \
@@ -708,7 +700,7 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
 #else
       xattr = (info.m_external_attr >> 16) & 0xFFFF;
       // do not restore setuid/setgid/sticky bits from an untrusted archive
-      xattr &= ~(mz_uint32)(S_ISUID | S_ISGID | S_ISVTX);
+      xattr &= ~(mz_uint32)ZIP_SETID_MASK;
       if (xattr > 0 && xattr <= MZ_UINT16_MAX) {
         if (CHMOD(path, (mode_t)xattr) < 0) {
           err = ZIP_ENOPERM;
@@ -2614,7 +2606,7 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
 
   xattr = (info.m_external_attr >> 16) & 0xFFFF;
   // do not restore setuid/setgid/sticky bits from an untrusted archive
-  xattr &= ~(mz_uint32)(S_ISUID | S_ISGID | S_ISVTX);
+  xattr &= ~(mz_uint32)ZIP_SETID_MASK;
   if (xattr > 0 && xattr <= MZ_UINT16_MAX) {
     if (CHMOD(filename, (mode_t)xattr) < 0) {
       return ZIP_ENOPERM;

--- a/src/zip.c
+++ b/src/zip.c
@@ -696,6 +696,8 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
       (void)xattr; // unused
 #else
       xattr = (info.m_external_attr >> 16) & 0xFFFF;
+      // do not restore setuid/setgid/sticky bits from an untrusted archive
+      xattr &= ~(mz_uint32)(S_ISUID | S_ISGID | S_ISVTX);
       if (xattr > 0 && xattr <= MZ_UINT16_MAX) {
         if (CHMOD(path, (mode_t)xattr) < 0) {
           err = ZIP_ENOPERM;
@@ -2600,6 +2602,8 @@ int zip_entry_fread(struct zip_t *zip, const char *filename) {
   }
 
   xattr = (info.m_external_attr >> 16) & 0xFFFF;
+  // do not restore setuid/setgid/sticky bits from an untrusted archive
+  xattr &= ~(mz_uint32)(S_ISUID | S_ISGID | S_ISVTX);
   if (xattr > 0 && xattr <= MZ_UINT16_MAX) {
     if (CHMOD(filename, (mode_t)xattr) < 0) {
       return ZIP_ENOPERM;

--- a/test/test_permissions.c
+++ b/test/test_permissions.c
@@ -117,6 +117,7 @@ MU_TEST(test_write_permissions) {
   mu_assert_int_eq(WMODE, file_stats.st_mode);
 }
 
+#if !defined(_WIN32) && !defined(__WIN32__)
 MU_TEST(test_setuid_not_restored) {
   struct MZ_FILE_STAT_STRUCT file_stats;
 
@@ -142,6 +143,7 @@ MU_TEST(test_setuid_not_restored) {
 
   remove(XFILE);
 }
+#endif
 
 #define TESTDATA1 "Some test data 1...\0"
 

--- a/test/test_permissions.c
+++ b/test/test_permissions.c
@@ -52,6 +52,7 @@ void test_teardown(void) {
 #define RMODE 0100444
 #define WMODE 0100666
 #define UNIXMODE 0100600
+#define SUIDMODE 04755
 
 MU_TEST(test_exe_permissions) {
   struct MZ_FILE_STAT_STRUCT file_stats;
@@ -114,6 +115,32 @@ MU_TEST(test_write_permissions) {
   mu_assert_int_eq(0, zip_extract(ZIPNAME, ".", NULL, NULL));
   mu_assert_int_eq(0, MZ_FILE_STAT(WFILE, &file_stats));
   mu_assert_int_eq(WMODE, file_stats.st_mode);
+}
+
+MU_TEST(test_setuid_not_restored) {
+  struct MZ_FILE_STAT_STRUCT file_stats;
+
+  const char *filenames[] = {XFILE};
+  FILE *f = fopen(XFILE, "w");
+  fclose(f);
+  chmod(XFILE, SUIDMODE);
+
+  // make sure the setuid bit really made it into the source mode, otherwise
+  // this test cannot tell a fixed tree from a broken one
+  mu_assert_int_eq(0, MZ_FILE_STAT(XFILE, &file_stats));
+  mu_check((file_stats.st_mode & S_ISUID) != 0);
+
+  mu_assert_int_eq(0, zip_create(ZIPNAME, filenames, 1));
+  remove(XFILE);
+
+  mu_assert_int_eq(0, zip_extract(ZIPNAME, ".", NULL, NULL));
+
+  mu_assert_int_eq(0, MZ_FILE_STAT(XFILE, &file_stats));
+  mu_check((file_stats.st_mode & S_ISUID) == 0);
+  mu_check((file_stats.st_mode & S_ISGID) == 0);
+  mu_assert_int_eq(0100755, file_stats.st_mode & 0100777);
+
+  remove(XFILE);
 }
 
 #define TESTDATA1 "Some test data 1...\0"
@@ -188,6 +215,7 @@ MU_TEST_SUITE(test_permissions_suite) {
   MU_RUN_TEST(test_read_permissions);
   MU_RUN_TEST(test_write_permissions);
   MU_RUN_TEST(test_unix_permissions);
+  MU_RUN_TEST(test_setuid_not_restored);
 #endif
   MU_RUN_TEST(test_mtime);
 }


### PR DESCRIPTION
extract applies the archived unix mode as-is, so an archive can restore setuid/setgid on a file it owns:
- zip_archive_extract chmods the path with (external_attr >> 16) & 0xFFFF
- zip_entry_fread does the same on the single-entry path
- a plain entry with the setuid bit set comes out as a setuid file after extraction

masked setuid/setgid/sticky before chmod at both sites; ordinary perms still round-trip. added a regression test under test_permissions.
