### PR TITLE
avoid signed-int overflow shifting mode bits in zip_entry_fwrite

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2225,7 +2225,8 @@ int zip_entry_fwrite(struct zip_t *zip, const char *filename) {
     modes |= UNX_IFIFO;
   if (S_ISSOCK(file_stat.st_mode))
     modes |= UNX_IFSOCK;
-  zip->entry.external_attr = (modes << 16) | !(file_stat.st_mode & S_IWUSR);
+  zip->entry.external_attr =
+      ((mz_uint32)modes << 16) | !(file_stat.st_mode & S_IWUSR);
   if ((file_stat.st_mode & S_IFMT) == S_IFDIR) {
     zip->entry.external_attr |= MZ_ZIP_DOS_DIR_ATTRIBUTE_BITFLAG;
   }


### PR DESCRIPTION
modes is mz_uint16, so `modes << 16` promotes to signed int and overflows for regular files:
- UNX_IFREG (0x8000) is always set on a regular file, so modes >= 0x8000 and the shift runs into the sign bit
- ubsan on the existing test_xattr suite: `left shift of 33188 by 16 places cannot be represented in type 'int'` at src/zip.c:2228
- reached on every zip_entry_fwrite / zip_create / append that stores a file mode

cast to mz_uint32 before the shift, the same form already used for the default attr a few lines up.
