### PR TITLE
fix non-terminating inflate loop in zip_entry_decrypt_and_read

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2342,23 +2342,23 @@ static ssize_t zip_entry_decrypt_and_read(struct zip_t *zip, void **buf,
       for (;;) {
         size_t in_avail = dec_size - in_pos;
         size_t out_avail = uncomp_size - out_pos;
-        int flags = TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
-        if (in_avail == 0)
-          flags |= TINFL_FLAG_HAS_MORE_INPUT;
 
-        tstatus = tinfl_decompress(
-            &decomp, dec_data + in_pos, &in_avail, (mz_uint8 *)out_buf,
-            (mz_uint8 *)out_buf + out_pos, &out_avail, flags);
+        tstatus = tinfl_decompress(&decomp, dec_data + in_pos, &in_avail,
+                                   (mz_uint8 *)out_buf,
+                                   (mz_uint8 *)out_buf + out_pos, &out_avail,
+                                   TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
         in_pos += in_avail;
         out_pos += out_avail;
 
         if (tstatus == TINFL_STATUS_DONE)
           break;
-        if (tstatus < 0) {
-          free(enc_data);
-          free(out_buf);
-          return (ssize_t)ZIP_EPASSWD;
-        }
+        // the whole payload is already in dec_data and the output buffer is
+        // sized to the declared uncomp_size, so a NEEDS_MORE_INPUT or
+        // HAS_MORE_OUTPUT result means the entry is truncated or its declared
+        // size is wrong; bail out instead of spinning on it
+        free(enc_data);
+        free(out_buf);
+        return (ssize_t)ZIP_EPASSWD;
       }
     }
 

--- a/test/test_password.c
+++ b/test/test_password.c
@@ -763,9 +763,75 @@ MU_TEST(test_password_deflate_oversized_uncomp_size) {
   zip_close(zip);
 }
 
+// A deflated, encrypted entry whose compressed size is truncated down to just
+// the 12-byte PKWARE encryption header has no deflate payload left to inflate.
+// zip_entry_read must reject it rather than spin forever feeding an empty
+// stream to the decompressor.
+MU_TEST(test_password_deflate_truncated_no_hang) {
+  struct zip_t *zip;
+  unsigned char *raw = NULL;
+  long raw_size = 0;
+  long i;
+  FILE *fp;
+  void *buf = NULL;
+  size_t bufsize = 0;
+  ssize_t n;
+
+  zip = zip_open_with_password(ZIPNAME, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w',
+                               PASSWORD);
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "deflate.txt"));
+  mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  fp = fopen(ZIPNAME, "rb");
+  mu_check(fp != NULL);
+  fseek(fp, 0, SEEK_END);
+  raw_size = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+  raw = (unsigned char *)malloc((size_t)raw_size);
+  mu_check(raw != NULL);
+  mu_check(fread(raw, 1, (size_t)raw_size, fp) == (size_t)raw_size);
+  fclose(fp);
+
+  // shrink the compressed-size field (offset 20) of the central dir header to
+  // the encryption-header size, leaving an empty deflate stream
+  for (i = 0; i + 30 <= raw_size; i++) {
+    if (raw[i] == 0x50 && raw[i + 1] == 0x4b && raw[i + 2] == 0x01 &&
+        raw[i + 3] == 0x02) {
+      raw[i + 20] = 12;
+      raw[i + 21] = 0x00;
+      raw[i + 22] = 0x00;
+      raw[i + 23] = 0x00;
+      break;
+    }
+  }
+  mu_check(i + 30 <= raw_size);
+
+  fp = fopen(ZIPNAME, "wb");
+  mu_check(fp != NULL);
+  mu_check(fwrite(raw, 1, (size_t)raw_size, fp) == (size_t)raw_size);
+  fclose(fp);
+  free(raw);
+
+  zip = zip_open_with_password(ZIPNAME, 0, 'r', PASSWORD);
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "deflate.txt"));
+  n = zip_entry_read(zip, &buf, &bufsize);
+  mu_check(n < 0);
+  if (buf) {
+    free(buf);
+    buf = NULL;
+  }
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+}
+
 MU_TEST_SUITE(test_password_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
+  MU_RUN_TEST(test_password_deflate_truncated_no_hang);
   MU_RUN_TEST(test_password_deflate_oversized_uncomp_size);
   MU_RUN_TEST(test_password_write_read);
   MU_RUN_TEST(test_password_stored);


### PR DESCRIPTION
the deflate branch hands the entire decrypted payload to tinfl in one buffer but mishandles the streaming state:
- TINFL_FLAG_HAS_MORE_INPUT was set when no input was left (in_avail == 0), the inverse of how the rest of miniz uses it
- the loop only stopped on TINFL_STATUS_DONE or a negative status, so a NEEDS_MORE_INPUT / HAS_MORE_OUTPUT result spins forever with no progress
- a crafted password-protected entry (comp_size cut down to the 12-byte encryption header, or a declared uncomp_size below the real output) hangs any caller of zip_entry_read / zip_entry_extract on that entry

dropped the flag and treat any non-DONE result as a corrupt entry returning ZIP_EPASSWD. added a regression test in test/test_password.c that hangs before the change and passes after.