### PR TITLE
guard against empty-archive underflow in zip_entry_finalize

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -891,6 +891,11 @@ static int zip_entry_finalize(struct zip_t *zip,
                               struct zip_entry_mark_t *entry_mark,
                               const size_t n) {
   size_t i = 0;
+  // nothing to finalize for an empty archive; n == 0 would underflow n - 1
+  // below and walk both arrays out of bounds
+  if (n == 0) {
+    return 0;
+  }
   mz_uint64 *local_header_ofs_array = (mz_uint64 *)calloc(n, sizeof(mz_uint64));
   if (!local_header_ofs_array) {
     return ZIP_EOOMEM;

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -338,6 +338,30 @@ MU_TEST(test_entries_deleteinvalid) {
   zip_close(zip);
 }
 
+MU_TEST(test_entries_delete_emptyarchive) {
+  char emptyname[L_tmpnam + 1] = {0};
+  strncpy(emptyname, "z-XXXXXX\0", L_tmpnam);
+  MKTEMP(emptyname);
+
+  struct zip_t *zip = zip_open(emptyname, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  mu_check(zip != NULL);
+  zip_close(zip);
+
+  char *names[] = {"whatever"};
+  zip = zip_open(emptyname, 0, 'd');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entries_delete(zip, names, 1));
+  zip_close(zip);
+
+  size_t idx[] = {0};
+  zip = zip_open(emptyname, 0, 'd');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entries_deletebyindex(zip, idx, 1));
+  zip_close(zip);
+
+  UNLINK(emptyname);
+}
+
 MU_TEST(test_entries_delete) {
   char *entries[] = {"delete.me", "_", "delete/file.1", "deleteme/file.3",
                      "delete/file.2"};
@@ -702,6 +726,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entry_read);
   MU_RUN_TEST(test_list_entries);
   MU_RUN_TEST(test_entries_deletebyindex);
+  MU_RUN_TEST(test_entries_delete_emptyarchive);
   MU_RUN_TEST(test_entries_delete);
   MU_RUN_TEST(test_entries_delete_stream);
   MU_RUN_TEST(test_entries_deletebyindex_stream);


### PR DESCRIPTION
deleting an entry from an archive with zero entries corrupts the heap:
- zip_entry_finalize takes the entry count n and uses n - 1 as a loop bound and final index; for n == 0 (size_t) that wraps to SIZE_MAX
- the loop then walks local_header_ofs_array and writes length[i] far past the calloc(0) buffers
- reachable from both zip_entries_delete and zip_entries_deletebyindex on an empty archive (confirmed SIGBUS)
Return early from zip_entry_finalize when n == 0, which covers both delete paths. Added a regression test that deletes from an empty archive by name and by index.