### PR TITLE
avoid signed overflow in zip_pkware_decrypt_byte

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -167,7 +167,7 @@ static void zip_pkware_keys_update(struct zip_pkware_keys_t *keys, mz_uint8 c) {
 
 /* Derives the next keystream byte from the current cipher state. */
 static mz_uint8 zip_pkware_decrypt_byte(const struct zip_pkware_keys_t *keys) {
-  mz_uint16 temp = (mz_uint16)(keys->key2 | 2);
+  mz_uint32 temp = (mz_uint16)(keys->key2 | 2);
   return (mz_uint8)((temp * (temp ^ 1)) >> 8);
 }
 


### PR DESCRIPTION
**Signed overflow in the PKWARE keystream byte**

`temp` is 16 bits but `temp * (temp ^ 1)` is evaluated as int, so for key2 values near the top of the range the product runs past INT_MAX (UBSAN flags it on any password-protected read or write). Widening `temp` to unsigned 32-bit keeps the multiply in range and yields the same keystream byte, so existing archives still round-trip.