### PR TITLE
free entry name in zip_close and zip_stream_close

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1488,6 +1488,7 @@ void zip_close(struct zip_t *zip) {
       mz_zip_reader_end(pZip);
     }
 
+    CLEANUP(zip->entry.name);
     CLEANUP(zip->password);
     CLEANUP(zip);
   }
@@ -2934,6 +2935,7 @@ void zip_stream_close(struct zip_t *zip) {
 #if ZIP_ENABLE_INFLATE
     mz_zip_reader_end(&(zip->archive));
 #endif
+    CLEANUP(zip->entry.name);
     CLEANUP(zip->password);
     CLEANUP(zip);
   }


### PR DESCRIPTION
entry.name is allocated when an entry is opened but only freed by zip_entry_close, so closing the archive with an entry still open leaks it:
- zip_close frees password and the handle but not zip->entry.name
- zip_stream_close has the same gap (zip_cstream_close routes through zip_close)

free it at both close points. CLEANUP no-ops when zip_entry_close already cleared the name, so no double free; the 12 tests stay green under asan/ubsan.