### PR TITLE
verify crc of decrypted entry in zip_entry_decrypt_and_read

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2374,6 +2374,15 @@ static ssize_t zip_entry_decrypt_and_read(struct zip_t *zip, void **buf,
       }
     }
 
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+    if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)out_buf, out_pos) !=
+        stat.m_crc32) {
+      free(enc_data);
+      free(out_buf);
+      return (ssize_t)ZIP_EPASSWD;
+    }
+#endif
+
     free(enc_data);
     *buf = out_buf;
     if (bufsize) {
@@ -2395,6 +2404,14 @@ static ssize_t zip_entry_decrypt_and_read(struct zip_t *zip, void **buf,
       dec_size = uncomp_size;
     }
     memcpy(out_buf, dec_data, dec_size);
+#ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
+    if (mz_crc32(MZ_CRC32_INIT, (const mz_uint8 *)out_buf, dec_size) !=
+        stat.m_crc32) {
+      free(enc_data);
+      free(out_buf);
+      return (ssize_t)ZIP_EPASSWD;
+    }
+#endif
     free(enc_data);
     *buf = out_buf;
     if (bufsize) {

--- a/test/test_password.c
+++ b/test/test_password.c
@@ -334,6 +334,36 @@ MU_TEST(test_password_wrong_password) {
   zip_close(zip);
 }
 
+MU_TEST(test_password_wrong_password_stored) {
+  struct zip_t *zip;
+  void *buf = NULL;
+  size_t bufsize = 0;
+  ssize_t n;
+
+  zip = zip_open_with_password(ZIPNAME, 0, 'w', PASSWORD);
+  mu_check(zip != NULL);
+
+  mu_assert_int_eq(0, zip_entry_open(zip, "stored-secret.txt"));
+  mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+
+  zip_close(zip);
+
+  zip = zip_open_with_password(ZIPNAME, 0, 'r', "wrong_password");
+  mu_check(zip != NULL);
+
+  mu_assert_int_eq(0, zip_entry_open(zip, "stored-secret.txt"));
+  n = zip_entry_read(zip, &buf, &bufsize);
+  mu_check(n < 0);
+  if (buf) {
+    free(buf);
+    buf = NULL;
+  }
+  mu_assert_int_eq(0, zip_entry_close(zip));
+
+  zip_close(zip);
+}
+
 MU_TEST(test_password_open_with_error) {
   struct zip_t *zip;
   int errnum = 0;
@@ -842,6 +872,7 @@ MU_TEST_SUITE(test_password_suite) {
   MU_RUN_TEST(test_password_null_is_no_encryption);
   MU_RUN_TEST(test_password_empty_is_no_encryption);
   MU_RUN_TEST(test_password_wrong_password);
+  MU_RUN_TEST(test_password_wrong_password_stored);
   MU_RUN_TEST(test_password_open_with_error);
   MU_RUN_TEST(test_password_entry_metadata);
   MU_RUN_TEST(test_password_extract_callback);


### PR DESCRIPTION
**Wrong password silently returns garbage for stored encrypted entries**
zip_entry_decrypt_and_read never checks the decrypted output against the entry's stored CRC, unlike miniz which verifies it on every unencrypted entry, so a stored (level 0) entry read with the wrong password hands back the keystream-XORed bytes as a successful read. Deflated entries already fail to inflate and error out; added the same CRC check to the stored and deflate branches so both return ZIP_EPASSWD on mismatch. Regression test covers the stored wrong-password case.