### PR TITLE
update central dir capacity after shrink in zip_central_dir_move

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1091,8 +1091,17 @@ static int zip_central_dir_move(mz_zip_internal_state *pState, int begin,
   }
 
   if (next && l_size == 0) {
+    mz_uint8 *shrunk = NULL;
     memmove(pState->m_central_dir.m_p, next, r_size);
-    pState->m_central_dir.m_p = MZ_REALLOC(pState->m_central_dir.m_p, r_size);
+    // shrinking the buffer must also lower m_capacity; otherwise the next
+    // mz_zip_array append sees the stale (larger) capacity, skips its realloc
+    // and writes past the smaller block. keep the old buffer on realloc
+    // failure.
+    shrunk = (mz_uint8 *)MZ_REALLOC(pState->m_central_dir.m_p, r_size);
+    if (shrunk) {
+      pState->m_central_dir.m_p = shrunk;
+      pState->m_central_dir.m_capacity = r_size;
+    }
     {
       int i;
       for (i = end; i < entry_num; i++) {

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -386,6 +386,44 @@ MU_TEST(test_entries_delete_emptyarchive) {
   UNLINK(emptyname);
 }
 
+MU_TEST(test_entries_deletefirst_then_add) {
+  // deleting the first central-directory entry shrinks the central-dir
+  // buffer; a following add must not write past the shrunk allocation.
+  char name[L_tmpnam + 1] = {0};
+  strncpy(name, "z-XXXXXX\0", L_tmpnam);
+  MKTEMP(name);
+
+  const char *names[] = {"aaa.txt", "bbb.txt", "ccc.txt", "ddd.txt"};
+  struct zip_t *zip = zip_open(name, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  mu_check(zip != NULL);
+  for (size_t i = 0; i < 4; ++i) {
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+  }
+  zip_close(zip);
+
+  size_t idx[] = {0};
+  zip = zip_open(name, ZIP_DEFAULT_COMPRESSION_LEVEL, 'a');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(1, zip_entries_deletebyindex(zip, idx, 1));
+  mu_assert_int_eq(0, zip_entry_open(zip, "new.txt"));
+  mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA2, strlen(TESTDATA2)));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  zip = zip_open(name, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(4, zip_entries_total(zip));
+  mu_assert_int_eq(ZIP_ENOENT, zip_entry_open(zip, "aaa.txt"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  mu_assert_int_eq(0, zip_entry_open(zip, "new.txt"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  UNLINK(name);
+}
+
 MU_TEST(test_entries_delete) {
   char *entries[] = {"delete.me", "_", "delete/file.1", "deleteme/file.3",
                      "delete/file.2"};
@@ -752,6 +790,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_list_entries);
   MU_RUN_TEST(test_entries_deletebyindex);
   MU_RUN_TEST(test_entries_delete_emptyarchive);
+  MU_RUN_TEST(test_entries_deletefirst_then_add);
   MU_RUN_TEST(test_entries_delete);
   MU_RUN_TEST(test_entries_delete_stream);
   MU_RUN_TEST(test_entries_deletebyindex_stream);


### PR DESCRIPTION
zip_central_dir_move reallocs the central directory smaller when the first entry is deleted but leaves m_capacity at the old size, so the next zip_entry_close append skips its own realloc and writes the new central-directory header past the shrunk buffer; lower m_capacity to match after the realloc.