### PR TITLE
fix infinite loop in zip_entry_noallocreadwithoffset on corrupt entry

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2534,47 +2534,28 @@ ssize_t zip_entry_noallocreadwithoffset(struct zip_t *zip, size_t offset,
   }
 
   {
-    mz_zip_reader_extract_iter_state *iter =
-        mz_zip_reader_extract_iter_new(pzip, (mz_uint)zip->entry.index, 0);
-    mz_uint8 *writebuf = (mz_uint8 *)buf;
-    size_t file_offset = 0;
-    size_t write_cursor = 0;
-    size_t to_read = size;
+    void *heap_buf = NULL;
+    size_t heap_size = 0;
 
-    if (!iter) {
+    // the streaming iterator (mz_zip_reader_extract_iter_*) spins forever on a
+    // memory-backed archive whose entry data does not inflate to the declared
+    // uncompressed size, so decode the whole entry up front like the password
+    // branch above and copy out the requested window
+    heap_buf = mz_zip_reader_extract_to_heap(pzip, (mz_uint)zip->entry.index,
+                                             &heap_size, 0);
+    if (!heap_buf) {
       return (ssize_t)ZIP_ENORITER;
     }
-
-    while (file_offset < zip->entry.uncomp_size && to_read > 0) {
-      size_t nread = mz_zip_reader_extract_iter_read(
-          iter, (void *)&writebuf[write_cursor], to_read);
-
-      if (nread == 0)
-        break;
-
-      if (offset < (file_offset + nread)) {
-        size_t read_cursor = offset - file_offset;
-        size_t read_size = nread - read_cursor;
-        MZ_ASSERT(read_cursor < size);
-
-        if (to_read < read_size)
-          read_size = to_read;
-        MZ_ASSERT(read_size <= size);
-
-        if (read_cursor != 0) {
-          memmove(&writebuf[write_cursor], &writebuf[read_cursor], read_size);
-        }
-
-        write_cursor += read_size;
-        offset += read_size;
-        to_read -= read_size;
-      }
-
-      file_offset += nread;
+    if (offset >= heap_size) {
+      free(heap_buf);
+      return (ssize_t)0;
     }
-
-    mz_zip_reader_extract_iter_free(iter);
-    return (ssize_t)write_cursor;
+    if (offset + size > heap_size) {
+      size = heap_size - offset;
+    }
+    memcpy(buf, (mz_uint8 *)heap_buf + offset, size);
+    free(heap_buf);
+    return (ssize_t)size;
   }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(test_read_out test_read.out)
 add_executable(${test_read_out} test_read.c)
 target_link_libraries(${test_read_out} zip)
 add_test(NAME ${test_read_out} COMMAND ${test_read_out})
+set_tests_properties(${test_read_out} PROPERTIES TIMEOUT 120)
 add_sanitizers(${test_read_out})
 
 set(test_extract_out test_extract.out)

--- a/test/test_read.c
+++ b/test/test_read.c
@@ -178,12 +178,56 @@ MU_TEST(test_noallocreadwithoffset) {
   zip_close(zip);
 }
 
+MU_TEST(test_noallocreadwithoffset_corrupt) {
+  // Build a multi-entry in-memory archive, then corrupt the first entry's local
+  // header filename length (offset 26) so its data offset no longer lines up
+  // with its compressed bytes while still pointing inside the archive. Before
+  // the fix this made zip_entry_noallocreadwithoffset loop forever on the
+  // memory-backed stream; it must now return instead of hanging.
+  char *abuf = NULL;
+  size_t asize = 0;
+  char big[5000];
+  size_t i;
+
+  struct zip_t *zw =
+      zip_stream_open(NULL, 0, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  mu_check(zw != NULL);
+  zip_entry_open(zw, "a/b.txt");
+  zip_entry_write(zw, TESTDATA1, strlen(TESTDATA1));
+  zip_entry_close(zw);
+  zip_entry_open(zw, "c.bin");
+  for (i = 0; i < sizeof(big); ++i) {
+    big[i] = (char)(i * 7 + 3);
+  }
+  zip_entry_write(zw, big, sizeof(big));
+  zip_entry_close(zw);
+  zip_stream_copy(zw, (void **)&abuf, &asize);
+  zip_stream_close(zw);
+
+  mu_check(abuf != NULL);
+  mu_check(asize > 28);
+  abuf[26] = (char)0xA5;
+
+  struct zip_t *zr = zip_stream_open(abuf, asize, 0, 'r');
+  if (zr != NULL) {
+    if (zip_entry_openbyindex(zr, 0) == 0) {
+      unsigned char out[64];
+      ssize_t n = zip_entry_noallocreadwithoffset(zr, 0, sizeof(out), out);
+      mu_check(n <= (ssize_t)sizeof(out));
+      zip_entry_close(zr);
+    }
+    zip_stream_close(zr);
+  }
+  free(abuf);
+}
+
 MU_TEST_SUITE(test_read_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_read);
   MU_RUN_TEST(test_noallocread);
   MU_RUN_TEST(test_noallocreadwithoffset);
+  MU_RUN_TEST(test_noallocreadwithoffset_corrupt);
 }
 
 #define UNUSED(x) (void)x


### PR DESCRIPTION
a memory-backed archive whose entry data never inflates to the declared uncompressed size makes mz_zip_reader_extract_iter_read loop forever (its in-memory path leaves the HAS_MORE_INPUT flag set so tinfl keeps returning NEEDS_MORE_INPUT with no input and never reaches DONE), so decode the whole entry with mz_zip_reader_extract_to_heap and copy out the requested window like the password branch already does; a ~5KB archive with a corrupted first local-header filename length hangs any caller at 100% cpu, while zip_entry_read on the same input already returns an error.