### PR TITLE
avoid offset+size overflow in zip_entry_noallocreadwithoffset

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -2533,7 +2533,10 @@ ssize_t zip_entry_noallocreadwithoffset(struct zip_t *zip, size_t offset,
     return (ssize_t)ZIP_EINVAL;
   }
 
-  if ((offset + size) > (size_t)zip->entry.uncomp_size) {
+  // offset < uncomp_size here, so test size against the remaining bytes; the
+  // original offset + size form wraps when size is near SIZE_MAX, skipping the
+  // clamp and leaving size huge for the memcpy below
+  if (size > (size_t)zip->entry.uncomp_size - offset) {
     size = (size_t)(zip->entry.uncomp_size - (mz_uint64)offset);
   }
 
@@ -2554,7 +2557,7 @@ ssize_t zip_entry_noallocreadwithoffset(struct zip_t *zip, size_t offset,
       free(heap_buf);
       return (ssize_t)0;
     }
-    if (offset + size > heap_size) {
+    if (size > heap_size - offset) {
       size = heap_size - offset;
     }
     memcpy(buf, (mz_uint8 *)heap_buf + offset, size);
@@ -2579,7 +2582,7 @@ ssize_t zip_entry_noallocreadwithoffset(struct zip_t *zip, size_t offset,
       free(heap_buf);
       return (ssize_t)0;
     }
-    if (offset + size > heap_size) {
+    if (size > heap_size - offset) {
       size = heap_size - offset;
     }
     memcpy(buf, (mz_uint8 *)heap_buf + offset, size);

--- a/test/test_read.c
+++ b/test/test_read.c
@@ -221,6 +221,28 @@ MU_TEST(test_noallocreadwithoffset_corrupt) {
   free(abuf);
 }
 
+MU_TEST(test_noallocreadwithoffset_hugesize) {
+  // A size large enough that offset + size wraps around size_t must still be
+  // clamped to the bytes remaining in the entry. Before the fix the wrapped
+  // sum skipped the clamp and the memcpy ran with the huge size, overrunning
+  // the buffer; the read must now be bounded by the entry size.
+  size_t entry_size = strlen(TESTDATA2);
+  size_t offset = 4;
+  char *buf = calloc(entry_size, sizeof(char));
+
+  struct zip_t *zip = zip_open(ZIPNAME, 0, 'r');
+  mu_check(zip != NULL);
+
+  mu_assert_int_eq(0, zip_entry_open(zip, "test/test-2.txt"));
+  ssize_t nread = zip_entry_noallocreadwithoffset(zip, offset, (size_t)-1, buf);
+  mu_assert_int_eq(entry_size - offset, (size_t)nread);
+  mu_assert_int_eq(0, strncmp(buf, TESTDATA2 + offset, (size_t)nread));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+
+  free(buf);
+  zip_close(zip);
+}
+
 MU_TEST_SUITE(test_read_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -228,6 +250,7 @@ MU_TEST_SUITE(test_read_suite) {
   MU_RUN_TEST(test_noallocread);
   MU_RUN_TEST(test_noallocreadwithoffset);
   MU_RUN_TEST(test_noallocreadwithoffset_corrupt);
+  MU_RUN_TEST(test_noallocreadwithoffset_hugesize);
 }
 
 #define UNUSED(x) (void)x


### PR DESCRIPTION
test size against the remaining entry bytes instead of offset + size in zip_entry_noallocreadwithoffset, since that sum wraps for a large size and skips the clamp, leaving the following memcpy to run past the decoded buffer.