### PR TITLE
harden and optimize entry delete path

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ free(buf);
 
 * Extract a partial zip entry
 
+Reads up to `size` bytes of the entry starting at `offset` into a caller-owned
+buffer (no internal allocation). `size` is clamped to the bytes remaining after
+`offset`, so it is safe to pass a size larger than what is left in the entry. The
+call returns the number of bytes actually written, or a negative error code (for
+example when `offset` is past the end of the entry).
+
 ```c
 unsigned char buf[16];
 size_t bufsize = sizeof(buf);
@@ -220,6 +226,9 @@ struct zip_t *zip = zip_open("foo.zip", 0, 'r');
     {
         size_t offset = 4;
         ssize_t nread = zip_entry_noallocreadwithoffset(zip, offset, bufsize, (void *)buf);
+        if (nread < 0) {
+            // offset out of range or read error
+        }
     }
 
     zip_entry_close(zip);

--- a/src/zip.c
+++ b/src/zip.c
@@ -1276,7 +1276,8 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
   // the per-entry lengths sum to at most the archive size, so a deleted_length
   // larger than the archive can only come from corrupted/overlapping offsets;
   // subtracting it would wrap m_archive_size and spin the stream writer's
-  // capacity-doubling loop forever (see #424), so refuse instead of underflowing
+  // capacity-doubling loop forever (see #424), so refuse instead of
+  // underflowing
   if ((mz_uint64)deleted_length > zip->archive.m_archive_size) {
     CLEANUP(deleted_entry_flag_array);
     return ZIP_EINVIDX;

--- a/src/zip.c
+++ b/src/zip.c
@@ -1038,6 +1038,13 @@ static ssize_t zip_files_move(struct zip_t *zip, mz_uint64 writen_num,
   const size_t page_size = 1 << 12; // 4K
   mz_zip_internal_state *pState = zip->archive.m_pState;
 
+  // moving zero bytes is a no-op; bail out before touching the heap so the
+  // common delete iterations that shift nothing (e.g. trailing entries) do not
+  // pay for a page-sized allocation each time
+  if (length == 0) {
+    return 0;
+  }
+
   mz_uint8 *move_buf = (mz_uint8 *)calloc(1, page_size);
   if (!move_buf) {
     return ZIP_EOOMEM;
@@ -1264,6 +1271,15 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
     writen_num += move_length;
     read_num += move_length;
     move_length = 0;
+  }
+
+  // the per-entry lengths sum to at most the archive size, so a deleted_length
+  // larger than the archive can only come from corrupted/overlapping offsets;
+  // subtracting it would wrap m_archive_size and spin the stream writer's
+  // capacity-doubling loop forever (see #424), so refuse instead of underflowing
+  if ((mz_uint64)deleted_length > zip->archive.m_archive_size) {
+    CLEANUP(deleted_entry_flag_array);
+    return ZIP_EINVIDX;
   }
 
   zip->archive.m_archive_size -= (mz_uint64)deleted_length;

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -479,6 +479,64 @@ MU_TEST(test_entries_delete_noncontiguous) {
   UNLINK(name);
 }
 
+MU_TEST(test_entries_delete_trailing) {
+  // deleting the last entry leaves no surviving bytes after it to shift, so the
+  // final delete iteration performs a zero-length move; deleting a middle entry
+  // in the same pass still has to shift the survivor that follows it. both the
+  // zero-length move and the per-run move-length reset must hold for the
+  // survivors to come out intact.
+  char name[L_tmpnam + 1] = {0};
+  strncpy(name, "z-XXXXXX\0", L_tmpnam);
+  MKTEMP(name);
+
+  const size_t len = 8192;
+  char *payload = (char *)malloc(len * 4);
+  mu_check(payload != NULL);
+  const char *names[] = {"a.bin", "b.bin", "c.bin", "d.bin"};
+
+  struct zip_t *zip = zip_open(name, 0, 'w');
+  mu_check(zip != NULL);
+  for (size_t i = 0; i < 4; ++i) {
+    char *p = payload + i * len;
+    memset(p, (int)('A' + i), len);
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zip, p, len));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+  }
+  zip_close(zip);
+
+  // remove a middle entry (b.bin -> c.bin must shift down) and the trailing
+  // entry (d.bin -> nothing to shift after it)
+  char *del[] = {"b.bin", "d.bin"};
+  zip = zip_open(name, 0, 'd');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(2, zip_entries_delete(zip, del, 2));
+  zip_close(zip);
+
+  zip = zip_open(name, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(2, zip_entries_total(zip));
+  const size_t survivors[] = {0, 2};
+  for (size_t s = 0; s < 2; ++s) {
+    size_t i = survivors[s];
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    char *buf = NULL;
+    size_t bufsize = 0;
+    ssize_t r = zip_entry_read(zip, (void **)&buf, &bufsize);
+    mu_assert_int_eq((int)len, (int)r);
+    mu_assert_int_eq((int)len, (int)bufsize);
+    mu_assert_int_eq(0, memcmp(buf, payload + i * len, len));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+    free(buf);
+  }
+  mu_assert_int_eq(ZIP_ENOENT, zip_entry_open(zip, "d.bin"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  free(payload);
+  UNLINK(name);
+}
+
 MU_TEST(test_entries_delete) {
   char *entries[] = {"delete.me", "_", "delete/file.1", "deleteme/file.3",
                      "delete/file.2"};
@@ -1034,6 +1092,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_emptyarchive);
   MU_RUN_TEST(test_entries_deletefirst_then_add);
   MU_RUN_TEST(test_entries_delete_noncontiguous);
+  MU_RUN_TEST(test_entries_delete_trailing);
   MU_RUN_TEST(test_entries_delete);
   MU_RUN_TEST(test_entries_delete_stream);
   MU_RUN_TEST(test_entries_deletebyindex_stream);


### PR DESCRIPTION
- skip the page-sized buffer allocation in zip_files_move when there is nothing to move (e.g. trailing-entry deletes shift zero bytes)
- refuse to delete when the summed deleted_length exceeds the archive size instead of underflowing m_archive_size and spinning the stream writer forever (defense-in-depth for the #424 class of bug)
- add test_entries_delete_trailing covering the zero-length move path
- document zip_entry_noallocreadwithoffset size clamping / return value