### PR TITLE
match only S_IFLNK in zip_stat_is_symlink

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -76,6 +76,7 @@
     }                                                                          \
   } while (0)
 
+#define UNX_IFMT 0170000   /* Unix file-type mask */
 #define UNX_IFDIR 0040000  /* Unix directory */
 #define UNX_IFREG 0100000  /* Unix regular file */
 #define UNX_IFSOCK 0140000 /* Unix socket (BSD, not SysV or Amiga) */
@@ -540,8 +541,9 @@ static mz_bool zip_stat_is_symlink(mz_uint16 version_made_by,
   mz_bool is_unix_or_macos =
       ((version_made_by >> 8) == 3) || ((version_made_by >> 8) == 19);
 
-  // and has sym link attribute (0x80 is file, 0x40 is directory)
-  return is_unix_or_macos && (external_attr & (0x20 << 24));
+  // and the Unix file-type field marks it a symbolic link; test the whole
+  // type field, not a single bit that block/char device modes also set
+  return is_unix_or_macos && (((external_attr >> 16) & UNX_IFMT) == UNX_IFLNK);
 }
 
 #if ZIP_ENABLE_INFLATE

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -191,7 +191,8 @@ struct sym_entry_t {
   const char *name;
   const char *data; // symlink target, or regular file content
   int is_symlink;
-  int dir_flag; // also set the DOS directory attribute bit
+  int dir_flag;       // also set the DOS directory attribute bit
+  unsigned long attr; // explicit external_attr override (0 = use default)
 };
 
 static void sym_put16(unsigned char *b, unsigned v) {
@@ -265,8 +266,10 @@ static void sym_write_zip(const char *path, const struct sym_entry_t *e,
     sym_put32(hdr + 20, (unsigned long)sizes[i]);
     sym_put32(hdr + 24, (unsigned long)sizes[i]);
     sym_put16(hdr + 28, (unsigned)namelen);
-    sym_put32(hdr + 38, (e[i].is_symlink ? 0xA1FF0000UL : 0x81A40000UL) |
-                            (e[i].dir_flag ? 0x10UL : 0UL));
+    sym_put32(hdr + 38,
+              (e[i].attr ? e[i].attr
+                         : (e[i].is_symlink ? 0xA1FF0000UL : 0x81A40000UL)) |
+                  (e[i].dir_flag ? 0x10UL : 0UL));
     sym_put32(hdr + 42, (unsigned long)offsets[i]);
     memcpy(buf + pos, hdr, 46);
     pos += 46;
@@ -410,6 +413,31 @@ MU_TEST(test_extract_symlink_zerolen_first_rejected) {
 }
 #endif
 
+MU_TEST(test_extract_chardev_not_symlink) {
+  // a character-device entry (S_IFCHR) shares the 0x2000 mode bit with S_IFLNK;
+  // the file-type test must match S_IFLNK exactly, otherwise the extractor runs
+  // the symlink() path for an entry the archive never marked as a link
+  static const struct sym_entry_t entries[] = {
+      {"dev", "innocent", 0, 0, 0x21FF0000UL}, // S_IFCHR | 0777
+  };
+  char tmpl[] = "ext-XXXXXX";
+  char *dir = mkdtemp(tmpl);
+  char p[512];
+  char got[512];
+  mu_check(dir != NULL);
+
+  sym_write_zip(ZIPNAME, entries, 1);
+  mu_assert_int_eq(0, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  // it must be a regular file holding the data, not a symlink to "innocent"
+  snprintf(p, sizeof(p), "%s/dev", dir);
+  mu_assert_int_eq(-1, (int)readlink(p, got, sizeof(got)));
+
+  char rm[512];
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
+
 MU_TEST_SUITE(test_extract_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -422,6 +450,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_climb_rejected);
   MU_RUN_TEST(test_extract_symlink_dirflag_rejected);
   MU_RUN_TEST(test_extract_symlink_zerolen_first_rejected);
+  MU_RUN_TEST(test_extract_chardev_not_symlink);
 #endif
 }
 

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -411,7 +411,6 @@ MU_TEST(test_extract_symlink_zerolen_first_rejected) {
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);
 }
-#endif
 
 MU_TEST(test_extract_chardev_not_symlink) {
   // a character-device entry (S_IFCHR) shares the 0x2000 mode bit with S_IFLNK;
@@ -437,6 +436,7 @@ MU_TEST(test_extract_chardev_not_symlink) {
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);
 }
+#endif
 
 MU_TEST_SUITE(test_extract_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -423,6 +423,10 @@ MU_TEST(test_extract_chardev_not_symlink) {
   char *dir = mkdtemp(tmpl);
   char p[512];
   char got[512];
+  struct stat st;
+  FILE *fp;
+  char content[16];
+  size_t nread;
   mu_check(dir != NULL);
 
   sym_write_zip(ZIPNAME, entries, 1);
@@ -430,8 +434,18 @@ MU_TEST(test_extract_chardev_not_symlink) {
 
   // it must be a regular file holding the data, not a symlink to "innocent"
   snprintf(p, sizeof(p), "%s/dev", dir);
-  mu_assert_int_eq(-1, (int)readlink(p, got, sizeof(got)));
+  mu_assert_int_eq(0, lstat(p, &st));
+  mu_check(S_ISREG(st.st_mode));
 
+  fp = fopen(p, "rb");
+  mu_check(fp != NULL);
+  memset(content, 0, sizeof(content));
+  nread = fread(content, 1, sizeof(content) - 1, fp);
+  fclose(fp);
+  mu_assert_int_eq((int)strlen("innocent"), (int)nread);
+  mu_assert_int_eq(0, strncmp(content, "innocent", nread));
+
+  mu_assert_int_eq(-1, (int)readlink(p, got, sizeof(got)));
   char rm[512];
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);


### PR DESCRIPTION
zip_stat_is_symlink tests a single mode bit (0x2000) instead of the file-type field, so on extract:
- char-device (S_IFCHR) and block-device (S_IFBLK) entries are taken for symlinks
- a crafted unix/macos archive thus drives the symlink() path for entries it never typed as links
- target validation still contains them, but symlink creation should be limited to real S_IFLNK entries
- mask the whole type field and compare against UNX_IFLNK; real symlinks still match

Test extracts an S_IFCHR entry and checks it lands as a regular file.