### PR TITLE
reject overlong entry paths in zip_archive_extract

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -649,6 +649,15 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
       goto out;
     }
 
+    // a name that does not fit gets silently truncated by the copy below; the
+    // symlink branch then measures escape depth from the full name while the
+    // link is created at the shortened path, so a long name plus a climbing
+    // target resolves outside the destination
+    if (strlen(info.m_filename) >= filename_size) {
+      err = ZIP_EINVENTNAME;
+      goto out;
+    }
+
 #if defined(_MSC_VER)
     strncpy_s(&path[dirlen], filename_size, info.m_filename, filename_size);
 #else

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -410,6 +410,45 @@ MU_TEST(test_extract_symlink_zerolen_first_rejected) {
 }
 #endif
 
+#if ZIP_HAVE_SYMLINK
+MU_TEST(test_extract_symlink_longname_rejected) {
+  // a name too long for the extraction path buffer was silently truncated, so
+  // the symlink got created at a shorter path than the name the escape check
+  // measured depth from; the full name carries three separators while the
+  // truncated link sits one level deep, so "../../../escape" passed the check
+  // yet resolved outside the destination. such names must be rejected.
+  char longname[512];
+  size_t k = 0;
+  struct sym_entry_t entries[1];
+  char tmpl[] = "ext-XXXXXX";
+  char *dir;
+  char rm[512];
+
+  memset(longname, 'A', 250);
+  k = 250;
+  longname[k++] = '/';
+  memset(longname + k, 'B', 252);
+  k += 252;
+  memcpy(longname + k, "/xx/link", 8);
+  k += 8;
+  longname[k] = '\0'; // 511 chars
+
+  entries[0].name = longname;
+  entries[0].data = "../../../escape";
+  entries[0].is_symlink = 1;
+  entries[0].dir_flag = 0;
+
+  dir = mkdtemp(tmpl);
+  mu_check(dir != NULL);
+
+  sym_write_zip(ZIPNAME, entries, 1);
+  mu_assert_int_eq(ZIP_EINVENTNAME, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
+#endif
+
 MU_TEST_SUITE(test_extract_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -422,6 +461,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_climb_rejected);
   MU_RUN_TEST(test_extract_symlink_dirflag_rejected);
   MU_RUN_TEST(test_extract_symlink_zerolen_first_rejected);
+  MU_RUN_TEST(test_extract_symlink_longname_rejected);
 #endif
 }
 


### PR DESCRIPTION
long entry names were silently truncated when building the extraction path:
- zip_archive_extract copies the normalized name into a fixed path buffer and forces a terminating NUL, dropping the tail
- the symlink branch measures escape depth from the full name yet creates the link at the shortened path
- a long symlink name whose trailing separators fall past the cut plus a `../`-climbing target then passes zip_symlink_target_escapes but resolves outside the destination (a 511-byte name with target `../../../escape` extracted under a short dir lands a symlink outside the extract root, with a 0 return)

reject names that do not fit the remaining path buffer before the copy; names that fit still extract. test added.