### PR TITLE
treat backslash as a literal byte in zip_symlink_target_escapes

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -557,7 +557,13 @@ static mz_bool zip_symlink_target_escapes(const char *link_name,
   long depth = 0;
   const char *p;
 
-  if (ISSLASH(target[0])) {
+  // symlink() stores the target verbatim and POSIX resolves it with '/' as the
+  // only separator; a backslash is an ordinary byte. Splitting the target on
+  // '\' would count "a\b" as two levels and let "a\b/../../escape" cancel its
+  // own ".." and climb out of the root. The link name keeps ISSLASH because
+  // zip_mkpath rewrites its '\' to '/' before the link is created, so each
+  // separator there is a real directory level.
+  if (target[0] == '/') {
     return MZ_TRUE;
   }
 
@@ -571,7 +577,7 @@ static mz_bool zip_symlink_target_escapes(const char *link_name,
   for (p = target; *p;) {
     const char *seg = p;
     size_t len = 0;
-    while (*p && !ISSLASH(*p)) {
+    while (*p && *p != '/') {
       ++p;
       ++len;
     }
@@ -582,7 +588,7 @@ static mz_bool zip_symlink_target_escapes(const char *link_name,
     } else if (!(len == 0 || (len == 1 && seg[0] == '.'))) {
       ++depth;
     }
-    while (ISSLASH(*p)) {
+    while (*p == '/') {
       ++p;
     }
   }

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -360,6 +360,26 @@ MU_TEST(test_extract_symlink_climb_rejected) {
   mu_check(system(rm) == 0);
 }
 
+MU_TEST(test_extract_symlink_backslash_climb_rejected) {
+  // a backslash is a literal filename byte in a Unix symlink target, not a path
+  // separator, so "a\b/../../escape" resolves two levels above the extraction
+  // root. the containment check must not treat "\" as a separator, which would
+  // count "a\b" as two levels deep and wrongly cancel the two "..".
+  static const struct sym_entry_t entries[] = {
+      {"esc", "a\\b/../../escape", 1},
+  };
+  char tmpl[] = "ext-XXXXXX";
+  char *dir = mkdtemp(tmpl);
+  mu_check(dir != NULL);
+
+  sym_write_zip(ZIPNAME, entries, 1);
+  mu_assert_int_eq(ZIP_EINVENTNAME, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  char rm[512];
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
+
 MU_TEST(test_extract_symlink_dirflag_rejected) {
   // a symlink entry flagged as a directory carries no data, so the no-alloc
   // extractor leaves symlink_to untouched; without the guard "victim" would be
@@ -420,6 +440,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_contained);
   MU_RUN_TEST(test_extract_symlink_absolute_rejected);
   MU_RUN_TEST(test_extract_symlink_climb_rejected);
+  MU_RUN_TEST(test_extract_symlink_backslash_climb_rejected);
   MU_RUN_TEST(test_extract_symlink_dirflag_rejected);
   MU_RUN_TEST(test_extract_symlink_zerolen_first_rejected);
 #endif


### PR DESCRIPTION
parse the symlink target with `/` as the only separator, otherwise a backslash in a leading component such as `a\b/../../escape` is counted as extra depth that cancels the two climbing `..`, so the containment check passes and the created link resolves above the extraction directory (the link name still uses ISSLASH since zip_mkpath rewrites its `\` to `/` before the link is made).