### PR TITLE
fix survivor offset compaction in zip_central_dir_delete

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1175,7 +1175,6 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
   int i = 0;
   int begin = 0;
   int end = 0;
-  int d_num = 0;
   while (i < entry_num) {
     while ((i < entry_num) && (!deleted_entry_index_array[i])) {
       i++;
@@ -1189,36 +1188,26 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
     zip_central_dir_move(pState, begin, end, entry_num);
   }
 
-  i = 0;
-  while (i < entry_num) {
-    while ((i < entry_num) && (!deleted_entry_index_array[i])) {
-      i++;
+  // every surviving entry already holds its rebased offset at its original
+  // index after the moves above, so pack the offsets down in one stable pass.
+  // the old per-run compaction copied the whole tail (including deleted slots
+  // not yet processed) into the survivor slots, so with two or more separated
+  // delete runs a survivor's offset was overwritten by a stale deleted-entry
+  // offset that points past the realloc-shrunk central directory; the next
+  // index lookup (zip_entry_openbyindex) then read out of bounds.
+  // m_central_dir_offsets holds one mz_uint32 element per file and m_size is an
+  // element count, not a byte count.
+  {
+    int w = 0;
+    for (i = 0; i < entry_num; i++) {
+      if (!deleted_entry_index_array[i]) {
+        MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32, w) =
+            MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32, i);
+        w++;
+      }
     }
-    begin = i;
-    if (begin == entry_num) {
-      break;
-    }
-    while ((i < entry_num) && (deleted_entry_index_array[i])) {
-      i++;
-    }
-    end = i;
-    int k = 0, j;
-    for (j = end; j < entry_num; j++) {
-      MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets, mz_uint32,
-                           begin + k) =
-          (mz_uint32)MZ_ZIP_ARRAY_ELEMENT(&pState->m_central_dir_offsets,
-                                          mz_uint32, j);
-      k++;
-    }
-    d_num += end - begin;
+    pState->m_central_dir_offsets.m_size = (size_t)w;
   }
-
-  // m_central_dir_offsets stores one mz_uint32 element per file, and m_size is
-  // an element count (set to m_total_files by the reader), not a byte count;
-  // multiplying by sizeof(mz_uint32) left it four times too large, so a later
-  // add wrote the new record's offset far past the live entries and stale slots
-  // were consumed as real central-dir offsets
-  pState->m_central_dir_offsets.m_size = (size_t)(entry_num - d_num);
   return 0;
 }
 

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -1231,6 +1231,53 @@ MU_TEST(test_entry_offset) {
   zip_close(zip);
 }
 
+MU_TEST(test_entries_delete_multirun_offsets) {
+  // delete two separated runs of entries, the first starting at index 0 so the
+  // central-dir buffer is realloc-shrunk, then keep operating on the same
+  // handle. the offsets-array compaction used to copy the whole tail (including
+  // deleted slots not yet processed) into the survivor slots, so a survivor's
+  // offset was overwritten with a stale deleted-entry offset that points past
+  // the shrunk buffer; the next index lookup then reads out of bounds. names
+  // have varying lengths so the central-dir records differ in size.
+  char name[L_tmpnam + 1] = {0};
+  strncpy(name, "z-XXXXXX\0", L_tmpnam);
+  MKTEMP(name);
+
+  const char *names[] = {"f0",        "file1", "kept_c",    "f3",
+                         "file4xxxx", "keptF", "keptG_long"};
+  struct zip_t *zip = zip_open(name, 0, 'w');
+  mu_check(zip != NULL);
+  for (size_t i = 0; i < 7; ++i) {
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+  }
+  zip_close(zip);
+
+  // remove indices {0,1,3,4} -> survivors kept_c, keptF, keptG_long; then drop
+  // the first survivor (kept_c) on the same handle
+  zip = zip_open(name, 0, 'd');
+  mu_check(zip != NULL);
+  size_t del1[] = {0, 1, 3, 4};
+  mu_assert_int_eq(4, zip_entries_deletebyindex(zip, del1, 4));
+  size_t del2[] = {0};
+  mu_assert_int_eq(1, zip_entries_deletebyindex(zip, del2, 1));
+  zip_close(zip);
+
+  zip = zip_open(name, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(2, zip_entries_total(zip));
+  mu_assert_int_eq(0, zip_entry_open(zip, "keptF"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  mu_assert_int_eq(0, zip_entry_open(zip, "keptG_long"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  mu_assert_int_eq(ZIP_ENOENT, zip_entry_open(zip, "kept_c"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  UNLINK(name);
+}
+
 MU_TEST_SUITE(test_entry_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -1258,6 +1305,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_badoffset);
   MU_RUN_TEST(test_entries_delete_reordered_cd);
   MU_RUN_TEST(test_entries_delete_reordered_cd_data);
+  MU_RUN_TEST(test_entries_delete_multirun_offsets);
   MU_RUN_TEST(test_entry_offset);
 }
 


### PR DESCRIPTION
**Out-of-bounds read on multi-run entry delete**
zip_central_dir_delete packs the offsets array one delete-run at a time, but each run copies the whole tail (deleted slots from later runs included) over the survivor slots, so with two or more disjoint runs a survivor offset is overwritten by a stale deleted-entry value that points past the realloc-shrunk central directory. The next index lookup on the same handle then reads out of bounds (ASan flags a 511-byte over-read through zip_entry_openbyindex on a 7-entry archive after deleting {0,1,3,4} then index 0). Switched the compaction to a single stable pass so a kept entry's offset is never clobbered.