### PR TITLE
don't realloc the caller's buffer in zip_stream_delete_write_func

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -112,8 +112,20 @@ static size_t zip_stream_delete_write_func(void *pOpaque, mz_uint64 file_ofs,
     size_t new_capacity = MZ_MAX(64, pState->m_mem_capacity);
     while (new_capacity < new_size)
       new_capacity *= 2;
-    if (NULL == (pNew_block = pZip->m_pRealloc(
-                     pZip->m_pAlloc_opaque, pState->m_pMem, 1, new_capacity))) {
+    if (pState->m_mem_capacity == 0) {
+      // m_pMem still aliases the caller-owned buffer passed to zip_stream_open
+      // (mz_zip_reader_init_mem stores it verbatim, leaving m_mem_capacity 0).
+      // Reallocating it would move and free a buffer the caller still owns and
+      // frees; copy into a library-owned block and leave the caller's intact.
+      pNew_block = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, new_capacity);
+      if (pNew_block) {
+        memcpy(pNew_block, pState->m_pMem, (size_t)pState->m_mem_size);
+      }
+    } else {
+      pNew_block = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pState->m_pMem, 1,
+                                    new_capacity);
+    }
+    if (NULL == pNew_block) {
       mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
       return 0;
     }
@@ -2945,6 +2957,12 @@ struct zip_t *zip_stream_openwitherror(const char *stream, size_t size,
         goto cleanup;
       }
       zip->archive.m_pWrite = zip_stream_delete_write_func;
+      // init_from_reader sets m_mem_capacity to the size of the caller-owned
+      // stream buffer and assumes it is heap-resizable. It is not ours to
+      // resize, so clear the capacity: the first write then copies it into a
+      // library-owned block (see zip_stream_delete_write_func) and a non-zero
+      // capacity afterwards reliably marks that owned block.
+      zip->archive.m_pState->m_mem_capacity = 0;
     } else {
       *errnum = ZIP_EINVMODE;
       goto cleanup;
@@ -3012,6 +3030,17 @@ ssize_t zip_stream_copy(struct zip_t *zip, void **buf, size_t *bufsize) {
 void zip_stream_close(struct zip_t *zip) {
   if (zip) {
 #if ZIP_ENABLE_DEFLATE
+    // in-memory delete mode grows a library-owned working copy of the archive
+    // in zip_stream_delete_write_func (m_mem_capacity becomes non-zero);
+    // release it here. writer_end leaves m_pMem alone for this write func,
+    // which is what keeps the caller's original stream buffer untouched.
+    if (zip->archive.m_pWrite == zip_stream_delete_write_func &&
+        zip->archive.m_pState && zip->archive.m_pState->m_pMem &&
+        zip->archive.m_pState->m_mem_capacity != 0) {
+      zip->archive.m_pFree(zip->archive.m_pAlloc_opaque,
+                           zip->archive.m_pState->m_pMem);
+      zip->archive.m_pState->m_pMem = NULL;
+    }
     mz_zip_writer_end(&(zip->archive));
 #endif
 #if ZIP_ENABLE_INFLATE

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -918,6 +918,60 @@ MU_TEST(test_entries_delete_stream_multi_copy) {
   free(copy2);
 }
 
+MU_TEST(test_entries_delete_stream_add_grow) {
+  // In-memory delete mode aliases the caller's stream buffer as the archive's
+  // working memory (mz_zip_reader_init_mem stores it verbatim). Adding an entry
+  // grows the archive past the original size; the writer must work on its own
+  // copy rather than realloc-and-free the caller's buffer, which the caller
+  // still owns and frees after zip_stream_close.
+  const char *names[] = {"a.txt", "b.txt"};
+  struct zip_t *zw =
+      zip_stream_open(NULL, 0, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  mu_check(zw != NULL);
+  for (size_t i = 0; i < 2; ++i) {
+    mu_assert_int_eq(0, zip_entry_open(zw, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zw, TESTDATA1, strlen(TESTDATA1)));
+    mu_assert_int_eq(0, zip_entry_close(zw));
+  }
+  void *zdata = NULL;
+  size_t zsize = 0;
+  mu_check(zip_stream_copy(zw, &zdata, &zsize) > 0);
+  zip_stream_close(zw);
+
+  const size_t biglen = 8192;
+  char *big = (char *)malloc(biglen);
+  mu_check(big != NULL);
+  memset(big, 'Z', biglen);
+
+  // store (level 0) so the added entry grows the archive well past zsize and
+  // the working buffer has to relocate
+  struct zip_t *zip = zip_stream_open((const char *)zdata, zsize, 0, 'd');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "big.bin"));
+  mu_assert_int_eq(0, zip_entry_write(zip, big, biglen));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+
+  void *outdata = NULL;
+  size_t outsize = 0;
+  mu_check(zip_stream_copy(zip, &outdata, &outsize) > 0);
+  zip_stream_close(zip);
+  free(zdata); // caller still owns the original buffer; must not double-free
+  free(big);
+
+  zip = zip_stream_open((const char *)outdata, outsize, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(3, zip_entries_total(zip));
+  mu_assert_int_eq(0, zip_entry_open(zip, "big.bin"));
+  mu_assert_int_eq((int)biglen, zip_entry_size(zip));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  for (size_t i = 0; i < 2; ++i) {
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+  }
+  zip_stream_close(zip);
+  free(outdata);
+}
+
 static unsigned int te_rd32(const unsigned char *p) {
   return (unsigned int)p[0] | ((unsigned int)p[1] << 8) |
          ((unsigned int)p[2] << 16) | ((unsigned int)p[3] << 24);
@@ -1302,6 +1356,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_stream_open_close);
   MU_RUN_TEST(test_entries_delete_stream_all);
   MU_RUN_TEST(test_entries_delete_stream_multi_copy);
+  MU_RUN_TEST(test_entries_delete_stream_add_grow);
   MU_RUN_TEST(test_entries_delete_badoffset);
   MU_RUN_TEST(test_entries_delete_reordered_cd);
   MU_RUN_TEST(test_entries_delete_reordered_cd_data);


### PR DESCRIPTION
in-memory delete mode reallocs the caller-owned stream buffer:
- zip_stream_open(...,'d') aliases the caller buffer as the archive memory (mz_zip_reader_init_mem), and init_from_reader then marks it heap-resizable
- the first write through zip_stream_delete_write_func reallocs it; growing the archive (e.g. adding an entry) relocates and frees the caller buffer, so the caller's own free() after zip_stream_close double-frees
- copy into a library-owned block on first growth and release that in zip_stream_close, leaving the caller buffer untouched
test_entries_delete_stream_add_grow fails before, passes after.