### PR TITLE
reject entry names that normalize to empty in zip_archive_extract

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -669,6 +669,16 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
       goto out;
     }
 
+    // a name built only from separators and "."/".." components (e.g. "..",
+    // "/", "./") normalizes to an empty string, so the path below collapses to
+    // the destination directory itself: a directory-flagged entry would then
+    // CHMOD the destination to the archive's mode and a regular entry would try
+    // to write over it
+    if (info.m_filename[0] == '\0') {
+      err = ZIP_EINVENTNAME;
+      goto out;
+    }
+
     // a name that does not fit gets silently truncated by the copy below; the
     // symlink branch then measures escape depth from the full name while the
     // link is created at the shortened path, so a long name plus a climbing

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -470,6 +470,31 @@ MU_TEST(test_extract_chardev_not_symlink) {
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);
 }
+
+MU_TEST(test_extract_dotdot_name_chmod_rejected) {
+  // an entry whose name normalizes to "" (e.g. "..") makes the extraction path
+  // collapse to the destination directory itself; a directory-flagged entry
+  // then chmods the destination to the archive's mode. it must be rejected.
+  static const struct sym_entry_t entries[] = {
+      {"..", "", 0, 1, 0x01FF0000UL}, // dir flag + unix mode 0777
+  };
+  char tmpl[] = "ext-XXXXXX";
+  char *dir = mkdtemp(tmpl);
+  struct stat st;
+  char rm[512];
+  mu_check(dir != NULL);
+  mu_check(chmod(dir, 0700) == 0);
+
+  sym_write_zip(ZIPNAME, entries, 1);
+  mu_assert_int_eq(ZIP_EINVENTNAME, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  // the destination directory keeps its original permissions
+  mu_assert_int_eq(0, stat(dir, &st));
+  mu_assert_int_eq(0700, (int)(st.st_mode & 0777));
+
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
 #endif
 
 #if ZIP_HAVE_SYMLINK
@@ -526,6 +551,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_zerolen_first_rejected);
   MU_RUN_TEST(test_extract_symlink_longname_rejected);
   MU_RUN_TEST(test_extract_chardev_not_symlink);
+  MU_RUN_TEST(test_extract_dotdot_name_chmod_rejected);
 #endif
 }
 


### PR DESCRIPTION
A crafted entry name that normalizes to "" chmods the extraction directory itself:
- zip_name_normalize drops "."/".." components and leading separators, so "..", "/" and "./" collapse to an empty name
- the built path then resolves to the destination dir, and a directory-flagged entry runs CHMOD on it with the mode from external_attr
- zip_extract/zip_stream_extract return success while the caller's target dir is left at any mode the archive picks (0777, 0000, ...)
Reject an empty normalized name before the path is built.