### PR TITLE
reject a symlink at the destination path in zip_archive_extract

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -732,6 +732,21 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
       }
 #endif
     } else {
+#if ZIP_HAVE_SYMLINK
+      // an earlier entry can create a symlink at this path (or one may already
+      // sit there); the fopen("wb") inside mz_zip_reader_extract_to_file and
+      // the CHMOD below both follow it, so a crafted archive that stores a
+      // symlink and then a regular entry of the same name writes through the
+      // link and clobbers its target. refuse to descend a symlink at the
+      // destination.
+      {
+        struct MZ_FILE_STAT_STRUCT path_st;
+        if (lstat(path, &path_st) == 0 && S_ISLNK(path_st.st_mode)) {
+          err = ZIP_ESYMLINK;
+          goto out;
+        }
+      }
+#endif
       if (!mz_zip_reader_is_file_a_directory(zip_archive, i)) {
         if (!mz_zip_reader_extract_to_file(zip_archive, i, path, 0)) {
           // Cannot extract zip archive to file

--- a/src/zip.c
+++ b/src/zip.c
@@ -733,17 +733,20 @@ static int zip_archive_extract(mz_zip_archive *zip_archive, const char *dir,
 #endif
     } else {
 #if ZIP_HAVE_SYMLINK
-      // an earlier entry can create a symlink at this path (or one may already
-      // sit there); the fopen("wb") inside mz_zip_reader_extract_to_file and
-      // the CHMOD below both follow it, so a crafted archive that stores a
-      // symlink and then a regular entry of the same name writes through the
-      // link and clobbers its target. refuse to descend a symlink at the
-      // destination.
+      // an earlier entry (or a pre-existing file) can leave a symlink at this
+      // path; the fopen("wb") inside mz_zip_reader_extract_to_file and the
+      // CHMOD below both follow it, so a regular entry of the same name would
+      // write through the link onto its target. remove the link first so the
+      // bytes land at the named path instead. this only covers a symlink as the
+      // final path component; a symlinked intermediate directory is not caught
+      // here.
       {
         struct MZ_FILE_STAT_STRUCT path_st;
         if (lstat(path, &path_st) == 0 && S_ISLNK(path_st.st_mode)) {
-          err = ZIP_ESYMLINK;
-          goto out;
+          if (unlink(path) != 0) {
+            err = ZIP_ESYMLINK;
+            goto out;
+          }
         }
       }
 #endif

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -498,9 +498,10 @@ MU_TEST(test_extract_dotdot_name_chmod_rejected) {
 
 MU_TEST(test_extract_symlink_writethrough_rejected) {
   // a regular entry whose name matches a symlink stored earlier in the same
-  // archive is written with fopen("wb"), which follows that link and writes
+  // archive is written with fopen("wb"), which would follow that link and write
   // through it, clobbering the link target instead of creating the named file.
-  // extraction must refuse to descend a symlink sitting at the destination.
+  // extraction removes the stale symlink first, so the bytes land at the named
+  // path and the link target is left untouched.
   static const struct sym_entry_t entries[] = {
       {"config", "victim", 1, 0},   // symlink config -> victim (in-tree target)
       {"config", "ATTACKER", 0, 0}, // regular file of the same name
@@ -508,8 +509,10 @@ MU_TEST(test_extract_symlink_writethrough_rejected) {
   char tmpl[] = "ext-XXXXXX";
   char *dir = mkdtemp(tmpl);
   char victim[512];
+  char config[512];
   char content[32];
   char rm[512];
+  struct stat st;
   FILE *fp;
   size_t nread;
   mu_check(dir != NULL);
@@ -522,7 +525,7 @@ MU_TEST(test_extract_symlink_writethrough_rejected) {
   fclose(fp);
 
   sym_write_zip(ZIPNAME, entries, sizeof(entries) / sizeof(entries[0]));
-  mu_assert_int_eq(ZIP_ESYMLINK, zip_extract(ZIPNAME, dir, NULL, NULL));
+  mu_assert_int_eq(0, zip_extract(ZIPNAME, dir, NULL, NULL));
 
   // the link target keeps its original bytes; nothing was written through it
   fp = fopen(victim, "rb");
@@ -532,6 +535,19 @@ MU_TEST(test_extract_symlink_writethrough_rejected) {
   fclose(fp);
   mu_assert_int_eq(8, (int)nread);
   mu_assert_int_eq(0, strncmp(content, "ORIGINAL", 8));
+
+  // the named path is now a regular file holding the entry's own bytes, not a
+  // link
+  snprintf(config, sizeof(config), "%s/config", dir);
+  mu_assert_int_eq(0, lstat(config, &st));
+  mu_check(S_ISREG(st.st_mode));
+  fp = fopen(config, "rb");
+  mu_check(fp != NULL);
+  memset(content, 0, sizeof(content));
+  nread = fread(content, 1, sizeof(content) - 1, fp);
+  fclose(fp);
+  mu_assert_int_eq((int)strlen("ATTACKER"), (int)nread);
+  mu_assert_int_eq(0, strncmp(content, "ATTACKER", nread));
 
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -495,6 +495,47 @@ MU_TEST(test_extract_dotdot_name_chmod_rejected) {
   snprintf(rm, sizeof(rm), "rm -rf %s", dir);
   mu_check(system(rm) == 0);
 }
+
+MU_TEST(test_extract_symlink_writethrough_rejected) {
+  // a regular entry whose name matches a symlink stored earlier in the same
+  // archive is written with fopen("wb"), which follows that link and writes
+  // through it, clobbering the link target instead of creating the named file.
+  // extraction must refuse to descend a symlink sitting at the destination.
+  static const struct sym_entry_t entries[] = {
+      {"config", "victim", 1, 0},   // symlink config -> victim (in-tree target)
+      {"config", "ATTACKER", 0, 0}, // regular file of the same name
+  };
+  char tmpl[] = "ext-XXXXXX";
+  char *dir = mkdtemp(tmpl);
+  char victim[512];
+  char content[32];
+  char rm[512];
+  FILE *fp;
+  size_t nread;
+  mu_check(dir != NULL);
+
+  // a pre-existing file in the destination that the link points at
+  snprintf(victim, sizeof(victim), "%s/victim", dir);
+  fp = fopen(victim, "wb");
+  mu_check(fp != NULL);
+  mu_check(fwrite("ORIGINAL", 1, 8, fp) == 8);
+  fclose(fp);
+
+  sym_write_zip(ZIPNAME, entries, sizeof(entries) / sizeof(entries[0]));
+  mu_assert_int_eq(ZIP_ESYMLINK, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  // the link target keeps its original bytes; nothing was written through it
+  fp = fopen(victim, "rb");
+  mu_check(fp != NULL);
+  memset(content, 0, sizeof(content));
+  nread = fread(content, 1, sizeof(content) - 1, fp);
+  fclose(fp);
+  mu_assert_int_eq(8, (int)nread);
+  mu_assert_int_eq(0, strncmp(content, "ORIGINAL", 8));
+
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
 #endif
 
 #if ZIP_HAVE_SYMLINK
@@ -552,6 +593,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_longname_rejected);
   MU_RUN_TEST(test_extract_chardev_not_symlink);
   MU_RUN_TEST(test_extract_dotdot_name_chmod_rejected);
+  MU_RUN_TEST(test_extract_symlink_writethrough_rejected);
 #endif
 }
 


### PR DESCRIPTION
**write-through symlink in zip_archive_extract**
A symlink entry followed by a regular entry of the same name makes the file write follow the link, so the entry's bytes overwrite whatever the link resolves to (an existing file in the destination) rather than the named path, and extraction still returns 0. Added an lstat check that refuses to extract onto a symlink at the destination.