### PR TITLE
reject descend-then-climb targets in zip_symlink_target_escapes

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -569,6 +569,7 @@ static mz_bool zip_stat_is_symlink(mz_uint16 version_made_by,
 static mz_bool zip_symlink_target_escapes(const char *link_name,
                                           const char *target) {
   long depth = 0;
+  mz_bool descended = MZ_FALSE;
   const char *p;
 
   // symlink() stores the target verbatim and POSIX resolves it with '/' as the
@@ -596,10 +597,18 @@ static mz_bool zip_symlink_target_escapes(const char *link_name,
       ++len;
     }
     if (len == 2 && seg[0] == '.' && seg[1] == '.') {
-      if (--depth < 0) {
+      // a ".." after a normal component is unsafe even when the running depth
+      // stays non-negative: that earlier component may itself be an in-tree
+      // symlink from a previous entry (e.g. "a" -> "."), so the kernel resolves
+      // "a/.." from a's target rather than from this directory and the link
+      // escapes the root. Only leading ".." (climbing the link's own real
+      // parents, which zip_mkpath refuses to descend through a symlink) is
+      // safe, bounded by the depth count.
+      if (descended || --depth < 0) {
         return MZ_TRUE;
       }
     } else if (!(len == 0 || (len == 1 && seg[0] == '.'))) {
+      descended = MZ_TRUE;
       ++depth;
     }
     while (*p == '/') {

--- a/test/test_extract.c
+++ b/test/test_extract.c
@@ -383,6 +383,33 @@ MU_TEST(test_extract_symlink_backslash_climb_rejected) {
   mu_check(system(rm) == 0);
 }
 
+MU_TEST(test_extract_symlink_chained_climb_rejected) {
+  // "a" -> "." is a harmless in-tree self link, but a later link whose target
+  // descends through it and then climbs ("a/../secret") escapes the root: the
+  // kernel resolves "a/.." from a's target (the extraction dir) so it lands in
+  // the parent. the lexical depth stays non-negative, so containment must also
+  // reject a ".." that follows a normal component.
+  static const struct sym_entry_t entries[] = {
+      {"a", ".", 1},
+      {"b", "a/../secret", 1},
+  };
+  char tmpl[] = "ext-XXXXXX";
+  char *dir = mkdtemp(tmpl);
+  char victim[512];
+  struct stat st;
+  mu_check(dir != NULL);
+
+  sym_write_zip(ZIPNAME, entries, 2);
+  mu_assert_int_eq(ZIP_EINVENTNAME, zip_extract(ZIPNAME, dir, NULL, NULL));
+
+  snprintf(victim, sizeof(victim), "%s/b", dir);
+  mu_check(lstat(victim, &st) != 0);
+
+  char rm[512];
+  snprintf(rm, sizeof(rm), "rm -rf %s", dir);
+  mu_check(system(rm) == 0);
+}
+
 MU_TEST(test_extract_symlink_dirflag_rejected) {
   // a symlink entry flagged as a directory carries no data, so the no-alloc
   // extractor leaves symlink_to untouched; without the guard "victim" would be
@@ -547,6 +574,7 @@ MU_TEST_SUITE(test_extract_suite) {
   MU_RUN_TEST(test_extract_symlink_absolute_rejected);
   MU_RUN_TEST(test_extract_symlink_climb_rejected);
   MU_RUN_TEST(test_extract_symlink_backslash_climb_rejected);
+  MU_RUN_TEST(test_extract_symlink_chained_climb_rejected);
   MU_RUN_TEST(test_extract_symlink_dirflag_rejected);
   MU_RUN_TEST(test_extract_symlink_zerolen_first_rejected);
   MU_RUN_TEST(test_extract_symlink_longname_rejected);


### PR DESCRIPTION
zip_symlink_target_escapes counts a target's depth lexically and treats every component as a real directory, so a chained in-tree symlink slips a climb past it:
- "a" -> "." is accepted as a harmless self link
- "b" -> "a/../secret" keeps the depth non-negative (a: +1, ..: 0, secret: +1) and is accepted too
- at resolution "a/.." is the parent of the extraction root, so "b" points outside it; reading through the extracted "b" returns a file from outside the destination dir

Reject a ".." that follows a normal component, since that component may itself be a symlink from an earlier entry. Leading ".." (climbing the link's own real parents, which zip_mkpath will not descend through a symlink) stays allowed. Regression test added.