### PR TITLE
add m_file_archive_start_ofs to raw file seeks on modify

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1123,7 +1123,12 @@ static ssize_t zip_files_move(struct zip_t *zip, mz_uint64 writen_num,
 
     if (pState->m_pFile) {
 #ifndef MINIZ_NO_STDIO
-      n = zip_file_move(pState->m_pFile, writen_num, read_num, move_count,
+      // writen_num/read_num are archive-relative; a stub-prefixed file needs
+      // m_file_archive_start_ofs added to reach the real bytes (the memory
+      // path below stays archive-relative, so it is left untouched)
+      n = zip_file_move(pState->m_pFile,
+                        writen_num + pState->m_file_archive_start_ofs,
+                        read_num + pState->m_file_archive_start_ofs, move_count,
                         move_buf, page_size);
 #else
       CLEANUP(move_buf);
@@ -2054,7 +2059,11 @@ int zip_entry_close(struct zip_t *zip) {
 
     if (pState->m_pFile) {
 #ifndef MINIZ_NO_STDIO
-      if (MZ_FSEEK64(pState->m_pFile, (mz_int64)zip->entry.enc_header_ofs,
+      // the writer callbacks add m_file_archive_start_ofs, so a raw seek must
+      // add it too or it lands before the archive on a stub-prefixed file
+      if (MZ_FSEEK64(pState->m_pFile,
+                     (mz_int64)(zip->entry.enc_header_ofs +
+                                pState->m_file_archive_start_ofs),
                      SEEK_SET)) {
         err = ZIP_EFSEEK;
         goto cleanup;
@@ -2106,7 +2115,9 @@ int zip_entry_close(struct zip_t *zip) {
 
         if (pState->m_pFile) {
 #ifndef MINIZ_NO_STDIO
-          if (MZ_FSEEK64(pState->m_pFile, (mz_int64)ofs, SEEK_SET)) {
+          if (MZ_FSEEK64(pState->m_pFile,
+                         (mz_int64)(ofs + pState->m_file_archive_start_ofs),
+                         SEEK_SET)) {
             err = ZIP_EFSEEK;
             goto cleanup;
           }

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -1332,6 +1332,84 @@ MU_TEST(test_entries_delete_multirun_offsets) {
   UNLINK(name);
 }
 
+MU_TEST(test_entries_delete_stub_prefixed) {
+  // a file archive can begin at a nonzero offset (a self-extracting stub or any
+  // prepended bytes); miniz records that base in m_file_archive_start_ofs and
+  // its read/write callbacks add it. the delete path's raw file moves used
+  // archive-relative offsets without that base, so on a stub-prefixed archive a
+  // surviving entry was rebuilt from the wrong bytes and read back corrupt.
+  char name[L_tmpnam + 1] = {0};
+  strncpy(name, "z-XXXXXX\0", L_tmpnam);
+  MKTEMP(name);
+
+  const size_t len = 8192;
+  char *payload = (char *)malloc(len * 3);
+  mu_check(payload != NULL);
+  const char *names[] = {"a.bin", "b.bin", "c.bin"};
+
+  struct zip_t *zip = zip_open(name, 0, 'w');
+  mu_check(zip != NULL);
+  for (size_t i = 0; i < 3; ++i) {
+    char *p = payload + i * len;
+    memset(p, (int)('A' + i), len);
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zip, p, len));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+  }
+  zip_close(zip);
+
+  // prepend a stub so the archive no longer starts at file offset 0
+  FILE *f = fopen(name, "rb");
+  mu_check(f != NULL);
+  fseek(f, 0, SEEK_END);
+  long zsize = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *zbytes = (char *)malloc((size_t)zsize);
+  mu_check(zbytes != NULL);
+  mu_assert_int_eq(zsize, (long)fread(zbytes, 1, (size_t)zsize, f));
+  fclose(f);
+
+  const size_t stub = 4096;
+  char *sb = (char *)malloc(stub);
+  mu_check(sb != NULL);
+  memset(sb, 'S', stub);
+  f = fopen(name, "wb");
+  mu_check(f != NULL);
+  mu_assert_int_eq((long)stub, (long)fwrite(sb, 1, stub, f));
+  mu_assert_int_eq(zsize, (long)fwrite(zbytes, 1, (size_t)zsize, f));
+  fclose(f);
+  free(sb);
+  free(zbytes);
+
+  // remove the middle entry -> c.bin must shift down over b.bin's old region
+  char *del[] = {"b.bin"};
+  zip = zip_open(name, 0, 'd');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(1, zip_entries_delete(zip, del, 1));
+  zip_close(zip);
+
+  zip = zip_open(name, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(2, zip_entries_total(zip));
+  const size_t survivors[] = {0, 2};
+  for (size_t s = 0; s < 2; ++s) {
+    size_t i = survivors[s];
+    mu_assert_int_eq(0, zip_entry_open(zip, names[i]));
+    char *buf = NULL;
+    size_t bufsize = 0;
+    ssize_t r = zip_entry_read(zip, (void **)&buf, &bufsize);
+    mu_assert_int_eq((int)len, (int)r);
+    mu_assert_int_eq((int)len, (int)bufsize);
+    mu_assert_int_eq(0, memcmp(buf, payload + i * len, len));
+    mu_assert_int_eq(0, zip_entry_close(zip));
+    free(buf);
+  }
+  zip_close(zip);
+
+  free(payload);
+  UNLINK(name);
+}
+
 MU_TEST_SUITE(test_entry_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -1361,6 +1439,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_reordered_cd);
   MU_RUN_TEST(test_entries_delete_reordered_cd_data);
   MU_RUN_TEST(test_entries_delete_multirun_offsets);
+  MU_RUN_TEST(test_entries_delete_stub_prefixed);
   MU_RUN_TEST(test_entry_offset);
 }
 

--- a/test/test_password.c
+++ b/test/test_password.c
@@ -858,6 +858,68 @@ MU_TEST(test_password_deflate_truncated_no_hang) {
   zip_close(zip);
 }
 
+MU_TEST(test_password_append_stub_prefixed) {
+  // a file archive can begin at a nonzero offset (a self-extracting stub);
+  // miniz records it in m_file_archive_start_ofs and its write callback adds
+  // it. zip_entry_close re-reads the just-written encryption header/data with a
+  // raw seek that omitted that base, so appending an encrypted entry to a
+  // stub-prefixed archive re-encrypted the wrong bytes and the entry read back
+  // as a wrong-password error.
+  struct zip_t *zip;
+
+  zip = zip_open_with_password(ZIPNAME, 0, 'w', PASSWORD);
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "first.txt"));
+  mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1)));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  // prepend a stub so the archive no longer starts at file offset 0
+  FILE *f = fopen(ZIPNAME, "rb");
+  mu_check(f != NULL);
+  fseek(f, 0, SEEK_END);
+  long zsize = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *zbytes = (char *)malloc((size_t)zsize);
+  mu_check(zbytes != NULL);
+  mu_assert_int_eq(zsize, (long)fread(zbytes, 1, (size_t)zsize, f));
+  fclose(f);
+
+  const size_t stub = 4096;
+  char *sb = (char *)malloc(stub);
+  mu_check(sb != NULL);
+  memset(sb, 'S', stub);
+  f = fopen(ZIPNAME, "wb");
+  mu_check(f != NULL);
+  mu_assert_int_eq((long)stub, (long)fwrite(sb, 1, stub, f));
+  mu_assert_int_eq(zsize, (long)fwrite(zbytes, 1, (size_t)zsize, f));
+  fclose(f);
+  free(sb);
+  free(zbytes);
+
+  // append an encrypted entry to the stub-prefixed archive
+  zip = zip_open_with_password(ZIPNAME, 0, 'a', PASSWORD);
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "second.txt"));
+  mu_assert_int_eq(0, zip_entry_write(zip, TESTDATA2, strlen(TESTDATA2)));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+
+  // the appended entry must decrypt back to its original contents
+  void *buf = NULL;
+  size_t bufsize = 0;
+  ssize_t n;
+  zip = zip_open_with_password(ZIPNAME, 0, 'r', PASSWORD);
+  mu_check(zip != NULL);
+  mu_assert_int_eq(0, zip_entry_open(zip, "second.txt"));
+  n = zip_entry_read(zip, &buf, &bufsize);
+  mu_assert_int_eq(strlen(TESTDATA2), (int)n);
+  mu_check(memcmp(buf, TESTDATA2, strlen(TESTDATA2)) == 0);
+  free(buf);
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_close(zip);
+}
+
 MU_TEST_SUITE(test_password_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -878,6 +940,7 @@ MU_TEST_SUITE(test_password_suite) {
   MU_RUN_TEST(test_password_extract_callback);
   MU_RUN_TEST(test_password_delete_entries);
   MU_RUN_TEST(test_password_delete_by_index);
+  MU_RUN_TEST(test_password_append_stub_prefixed);
   MU_RUN_TEST(test_password_large_data);
   MU_RUN_TEST(test_password_multiple_writes);
   MU_RUN_TEST(test_password_stream_stored);


### PR DESCRIPTION
**Corrupt data when modifying a stub-prefixed archive**
A file archive that starts at a nonzero offset (a self-extracting stub or prepended bytes) keeps that base in m_file_archive_start_ofs, which the miniz read/write callbacks add but the delete path's file moves and the encrypted-append fix-up in zip_entry_close skip, so their raw seeks land before the archive and a delete corrupts a survivor while an appended encrypted entry reads back as a wrong-password error. Adding the base to those seeks matches zip_archive_truncate; the two new tests fail on master and pass with the fix.