### PR TITLE
avoid size_t overflow in zip_central_dir_move middle-run check

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1203,7 +1203,11 @@ static int zip_central_dir_move(mz_zip_internal_state *pState, int begin,
     }
   }
 
-  if (next && l_size * r_size != 0) {
+  // deleted run in the middle: survivors on both sides. test each size
+  // against zero directly; l_size * r_size is computed in size_t and wraps to
+  // zero on a 32-bit size_t build when both sides are a multiple of 64 KiB,
+  // which would skip the shift and the offset rebase below.
+  if (next && l_size != 0 && r_size != 0) {
     memmove(deleted, next, r_size);
     {
       int i;


### PR DESCRIPTION
middle-run guard in zip_central_dir_move uses a size_t multiply to mean both sides have survivors:
- l_size * r_size wraps to 0 on a 32-bit size_t build when both are a multiple of 64 KiB (reachable via ~64 KiB entry names)
- the branch is skipped, so surviving records after the deleted run are not shifted over the gap and their central-dir offsets not rebased, while m_central_dir.m_size is still lowered
- the finalized archive's central directory is left desynced from its offset table

test each size against zero directly; behavior is identical on 64-bit.