### PR TITLE
copy the caller buffer before in-place moves in zip_files_move

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1135,6 +1135,24 @@ static ssize_t zip_files_move(struct zip_t *zip, mz_uint64 writen_num,
       return ZIP_ENOFILE;
 #endif /* MINIZ_NO_STDIO */
     } else if (pState->m_pMem) {
+      // 'd' mode aliases the caller-owned buffer as m_pMem with m_mem_capacity
+      // 0; shifting entry data in place would write through it (a crash on a
+      // read-only backing, silent corruption otherwise). The copy-on-write in
+      // zip_stream_delete_write_func only covers the central-directory write,
+      // so copy into a library-owned block on the first move here too; a
+      // non-zero m_mem_capacity then marks the owned block that
+      // zip_stream_close frees.
+      if (pState->m_mem_capacity == 0) {
+        void *owned = zip->archive.m_pAlloc(zip->archive.m_pAlloc_opaque, 1,
+                                            pState->m_mem_size);
+        if (!owned) {
+          CLEANUP(move_buf);
+          return ZIP_EOOMEM;
+        }
+        memcpy(owned, pState->m_pMem, pState->m_mem_size);
+        pState->m_pMem = owned;
+        pState->m_mem_capacity = pState->m_mem_size;
+      }
       n = zip_mem_move(pState->m_pMem, pState->m_mem_size, writen_num, read_num,
                        move_count);
     } else {

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -972,6 +972,57 @@ MU_TEST(test_entries_delete_stream_add_grow) {
   free(outdata);
 }
 
+MU_TEST(test_entries_delete_stream_buffer_untouched) {
+  // In-memory delete mode compacts surviving entries by shifting their data in
+  // place. That shift must run on a library-owned copy, not on the caller's
+  // stream buffer (which the caller still owns): writing through it crashes on
+  // a read-only backing and silently corrupts a writable one. Deleting the
+  // first entry makes the second a MOVE, so the compaction shift runs.
+  const char *names[] = {"a.txt", "b.txt"};
+  struct zip_t *zw =
+      zip_stream_open(NULL, 0, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+  mu_check(zw != NULL);
+  for (size_t i = 0; i < 2; ++i) {
+    mu_assert_int_eq(0, zip_entry_open(zw, names[i]));
+    mu_assert_int_eq(0, zip_entry_write(zw, TESTDATA1, strlen(TESTDATA1)));
+    mu_assert_int_eq(0, zip_entry_close(zw));
+  }
+  void *zdata = NULL;
+  size_t zsize = 0;
+  mu_check(zip_stream_copy(zw, &zdata, &zsize) > 0);
+  zip_stream_close(zw);
+
+  char *pristine = (char *)malloc(zsize);
+  mu_check(pristine != NULL);
+  memcpy(pristine, zdata, zsize);
+
+  struct zip_t *zip = zip_stream_open((const char *)zdata, zsize, 0, 'd');
+  mu_check(zip != NULL);
+  char *entries[] = {"a.txt"};
+  mu_assert_int_eq(1, zip_entries_delete(zip, entries, 1));
+
+  void *outdata = NULL;
+  size_t outsize = 0;
+  mu_check(zip_stream_copy(zip, &outdata, &outsize) > 0);
+  zip_stream_close(zip);
+
+  // the caller's buffer must be byte-for-byte what it was before the delete
+  mu_assert_int_eq(0, memcmp(zdata, pristine, zsize));
+
+  free(pristine);
+  free(zdata);
+
+  zip = zip_stream_open((const char *)outdata, outsize, 0, 'r');
+  mu_check(zip != NULL);
+  mu_assert_int_eq(1, zip_entries_total(zip));
+  mu_assert_int_eq(ZIP_ENOENT, zip_entry_open(zip, "a.txt"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  mu_assert_int_eq(0, zip_entry_open(zip, "b.txt"));
+  mu_assert_int_eq(0, zip_entry_close(zip));
+  zip_stream_close(zip);
+  free(outdata);
+}
+
 static unsigned int te_rd32(const unsigned char *p) {
   return (unsigned int)p[0] | ((unsigned int)p[1] << 8) |
          ((unsigned int)p[2] << 16) | ((unsigned int)p[3] << 24);
@@ -1435,6 +1486,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_stream_all);
   MU_RUN_TEST(test_entries_delete_stream_multi_copy);
   MU_RUN_TEST(test_entries_delete_stream_add_grow);
+  MU_RUN_TEST(test_entries_delete_stream_buffer_untouched);
   MU_RUN_TEST(test_entries_delete_badoffset);
   MU_RUN_TEST(test_entries_delete_reordered_cd);
   MU_RUN_TEST(test_entries_delete_reordered_cd_data);


### PR DESCRIPTION
In-memory delete mode shifts surviving entry data straight through the caller-owned stream buffer:
- zip_stream_open(..., 'd') aliases the caller's buffer as m_pMem with m_mem_capacity 0
- zip_entries_delete -> zip_files_move -> zip_mem_move memmoves onto m_pMem to compact, before any write_func call
- the copy-on-write only guards the write/central-dir path, so this shift is unprotected

On a read-only backing (const/.rodata/PROT_READ mmap) that memmove is a write-through-const fault; on a writable buffer it silently mutates the caller's original bytes. Copy into a library-owned block on the first move, matching zip_stream_delete_write_func, so zip_stream_close frees it. Added test_entries_delete_stream_buffer_untouched (fails on master, passes here).