### PR TITLE
rebase zip64 local-header offset in zip_entries_delete_mark

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -1287,6 +1287,52 @@ static int zip_central_dir_delete(mz_zip_internal_state *pState,
   return 0;
 }
 
+// Rebase a surviving entry's local-header offset to new_ofs after a delete
+// shifts its data. A non-zip64 entry keeps the offset in the 32-bit
+// central-directory field. A zip64 entry keeps that field at the 0xFFFFFFFF
+// sentinel and stores the real offset in the zip64 extended-information extra
+// field (after the optional 64-bit uncompressed/compressed sizes, which are
+// present only when their own 32-bit fields are the sentinel too); rewrite it
+// there so the entry stays locatable. Returns 0 on success.
+static int zip_cdh_set_local_offset(mz_uint8 *p, mz_uint64 new_ofs) {
+  if (MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS) != MZ_UINT32_MAX) {
+    MZ_WRITE_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS, (mz_uint32)new_ofs);
+    return 0;
+  }
+
+  mz_uint16 fname_len = MZ_READ_LE16(p + MZ_ZIP_CDH_FILENAME_LEN_OFS);
+  mz_uint32 extra_rem = MZ_READ_LE16(p + MZ_ZIP_CDH_EXTRA_LEN_OFS);
+  mz_uint8 *extra = p + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE + fname_len;
+  mz_uint32 skip = 0;
+
+  // the zip64 field stores 64-bit uncompressed then compressed size ahead of
+  // the offset, each present only when its own 32-bit field is the sentinel
+  if (MZ_READ_LE32(p + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS) == MZ_UINT32_MAX) {
+    skip += 8;
+  }
+  if (MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS) == MZ_UINT32_MAX) {
+    skip += 8;
+  }
+
+  while (extra_rem >= 4) {
+    mz_uint16 field_id = MZ_READ_LE16(extra);
+    mz_uint16 field_size = MZ_READ_LE16(extra + 2);
+    if ((mz_uint32)field_size + 4 > extra_rem) {
+      break;
+    }
+    if (field_id == MZ_ZIP64_EXTENDED_INFORMATION_FIELD_HEADER_ID) {
+      if ((mz_uint32)field_size >= skip + 8) {
+        MZ_WRITE_LE64(extra + 4 + skip, new_ofs);
+        return 0;
+      }
+      break;
+    }
+    extra += 4 + field_size;
+    extra_rem -= 4 + field_size;
+  }
+  return ZIP_ENOHDR;
+}
+
 static ssize_t zip_entries_delete_mark(struct zip_t *zip,
                                        struct zip_entry_mark_t *entry_mark,
                                        int entry_num) {
@@ -1367,9 +1413,17 @@ static ssize_t zip_entries_delete_mark(struct zip_t *zip,
         CLEANUP(deleted_entry_flag_array);
         return ZIP_ENOENT;
       }
-      mz_uint32 offset = MZ_READ_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS);
-      offset -= (mz_uint32)deleted_length;
-      MZ_WRITE_LE32(p + MZ_ZIP_CDH_LOCAL_HEADER_OFS, offset);
+      // a zip64 entry keeps the sentinel in this 32-bit field and the real
+      // offset in an extra field; rebasing the raw field would corrupt the
+      // sentinel and leave the entry unlocatable, so rebase the resolved offset
+      // wherever it actually lives
+      if (zip_cdh_set_local_offset(
+              p, entry_mark[offset_order[i]].m_local_header_ofs -
+                     deleted_length) < 0) {
+        CLEANUP(offset_order);
+        CLEANUP(deleted_entry_flag_array);
+        return ZIP_ENOHDR;
+      }
       i++;
     }
 

--- a/test/test_entry.c
+++ b/test/test_entry.c
@@ -1123,6 +1123,107 @@ MU_TEST(test_entries_delete_badoffset) {
   free(nb);
 }
 
+// A zip64 entry keeps 0xFFFFFFFF in the 32-bit central-directory offset field
+// and stores the real local-header offset in a zip64 extra field. Deleting a
+// preceding entry shifts its data, and zip_entries_delete_mark rebased the raw
+// 32-bit field, corrupting the sentinel and leaving the extra-field offset
+// stale, so the surviving entry became unlocatable (read failed). The rebase
+// must update the offset where it actually lives and keep the entry readable.
+MU_TEST(test_entries_delete_zip64_offset) {
+  struct zip_t *zip = zip_stream_open(NULL, 0, 0, 'w');
+  mu_check(zip != NULL);
+  zip_entry_open(zip, "a.txt");
+  zip_entry_write(zip, TESTDATA1, strlen(TESTDATA1));
+  zip_entry_close(zip);
+  zip_entry_open(zip, "b.txt");
+  zip_entry_write(zip, TESTDATA2, strlen(TESTDATA2));
+  zip_entry_close(zip);
+
+  void *buf = NULL;
+  size_t bufsize = 0;
+  mu_check(zip_stream_copy(zip, &buf, &bufsize) > 0);
+  zip_stream_close(zip);
+
+  unsigned char *b = (unsigned char *)buf;
+  ssize_t eocd = -1, i;
+  for (i = (ssize_t)bufsize - 22; i >= 0; i--) {
+    if (te_rd32(b + i) == 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  mu_check(eocd >= 0);
+
+  unsigned int cd_ofs = te_rd32(b + eocd + 16);
+  unsigned char *p0 = b + cd_ofs;
+  unsigned int hdr0 =
+      46u + te_rd16(p0 + 28) + te_rd16(p0 + 30) + te_rd16(p0 + 32);
+  unsigned char *p1 = p0 + hdr0; // b.txt central-directory record
+  unsigned short fn1 = te_rd16(p1 + 28), ex1 = te_rd16(p1 + 30),
+                 cm1 = te_rd16(p1 + 32);
+  unsigned int real_comp = te_rd32(p1 + 20);
+  unsigned int real_ofs = te_rd32(p1 + 42);
+
+  // re-encode b.txt with zip64 comp-size and local-offset sentinels; the real
+  // values go into a zip64 extended-information extra field
+  unsigned char z64[4 + 16];
+  te_wr16(z64, 0x0001);
+  te_wr16(z64 + 2, 16);
+  te_wr64(z64 + 4, real_comp);
+  te_wr64(z64 + 12, real_ofs);
+
+  unsigned short newex1 = sizeof(z64);
+  size_t newhdr1 = 46u + fn1 + newex1 + cm1;
+  unsigned char *ne = (unsigned char *)calloc(1, newhdr1);
+  mu_check(ne != NULL);
+  memcpy(ne, p1, 46u + fn1);
+  memcpy(ne + 46u + fn1, z64, sizeof(z64));
+  memcpy(ne + 46u + fn1 + newex1, p1 + 46u + fn1 + ex1, cm1);
+  te_wr32(ne + 20, 0xFFFFFFFF); // comp size sentinel
+  te_wr32(ne + 42, 0xFFFFFFFF); // local-header offset sentinel
+  te_wr16(ne + 30, newex1);
+
+  size_t cd_new_len = hdr0 + newhdr1;
+  size_t eocd_len = bufsize - (size_t)eocd;
+  size_t total_new = cd_ofs + cd_new_len + eocd_len;
+  unsigned char *nb = (unsigned char *)calloc(1, total_new);
+  mu_check(nb != NULL);
+  memcpy(nb, b, cd_ofs);
+  memcpy(nb + cd_ofs, p0, hdr0);
+  memcpy(nb + cd_ofs + hdr0, ne, newhdr1);
+  memcpy(nb + cd_ofs + cd_new_len, b + eocd, eocd_len);
+  te_wr32(nb + cd_ofs + cd_new_len + 12, (unsigned int)cd_new_len);
+  te_wr32(nb + cd_ofs + cd_new_len + 16, cd_ofs);
+
+  // deleting a.txt shifts b.txt to the front of the archive
+  struct zip_t *zd = zip_stream_open((const char *)nb, total_new, 0, 'd');
+  mu_check(zd != NULL);
+  char *del[] = {"a.txt"};
+  mu_assert_int_eq(1, (int)zip_entries_delete(zd, del, 1));
+  void *out = NULL;
+  size_t outsize = 0;
+  mu_check(zip_stream_copy(zd, &out, &outsize) > 0);
+  zip_stream_close(zd);
+
+  struct zip_t *zr = zip_stream_open((const char *)out, outsize, 0, 'r');
+  mu_check(zr != NULL);
+  mu_assert_int_eq(1, (int)zip_entries_total(zr));
+  mu_assert_int_eq(0, zip_entry_open(zr, "b.txt"));
+  void *rd = NULL;
+  size_t rdsize = 0;
+  mu_assert_int_eq((int)strlen(TESTDATA2),
+                   (int)zip_entry_read(zr, &rd, &rdsize));
+  mu_check(rd != NULL && memcmp(rd, TESTDATA2, strlen(TESTDATA2)) == 0);
+  free(rd);
+  zip_entry_close(zr);
+  zip_stream_close(zr);
+
+  free(buf);
+  free(ne);
+  free(nb);
+  free(out);
+}
+
 // When the central-directory records are not stored in local-header-offset
 // order, zip_index_update used to assign a duplicate file_index, so one entry's
 // length was counted twice. The summed deleted length could exceed the archive
@@ -1488,6 +1589,7 @@ MU_TEST_SUITE(test_entry_suite) {
   MU_RUN_TEST(test_entries_delete_stream_add_grow);
   MU_RUN_TEST(test_entries_delete_stream_buffer_untouched);
   MU_RUN_TEST(test_entries_delete_badoffset);
+  MU_RUN_TEST(test_entries_delete_zip64_offset);
   MU_RUN_TEST(test_entries_delete_reordered_cd);
   MU_RUN_TEST(test_entries_delete_reordered_cd_data);
   MU_RUN_TEST(test_entries_delete_multirun_offsets);


### PR DESCRIPTION
zip_entries_delete_mark rebases the wrong offset field for a zip64 entry:
- after a delete shifts an entry data it rewrites the raw 32-bit central-directory offset field
- a zip64 entry holds 0xFFFFFFFF there and keeps the real offset in an extra field, so the subtract turns the sentinel into 0xFFFFFFFF - deleted_length and leaves the extra field stale, and the survivor can no longer be located (read fails)
- zip_cdh_set_local_offset now writes the resolved offset into the zip64 extra field for such entries and the 32-bit field otherwise

repro: craft a zip64 archive, delete a preceding entry, read the survivor back. test_entries_delete_zip64_offset fails on master and passes here.